### PR TITLE
Add MCMC Modes 5-10 and Tunable nWRITE Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.swp.*
 *.out
 *.out.*
+*.log*
 DUMPFILES
 MATLAB/startup.m
 MATLAB/CARDAMOM_DISK/*

--- a/C/mcmc_fun/MHMCMC/MCMC_FUN/AFDEMCMCZS.c
+++ b/C/mcmc_fun/MHMCMC/MCMC_FUN/AFDEMCMCZS.c
@@ -1,0 +1,239 @@
+#pragma once
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "../../../math_fun/std.c"
+#include "NORMPARS.c"
+#include "STEP_AFDEMCMC.c"
+#include "STEP_DEMCMCZS.c"
+#include "WRITE_DEMCMC_RESULTS.c"
+
+/*here including additional functions needed to initialise and clear memory*/
+#include "INITIALIZE_MCMC_OUTPUT.c"
+
+/*Hybrid affine-invariant / DE-MCZS sampler.
+ *
+ * For the first fADAPT fraction of the run, this follows AFDEMCMC and uses
+ * STEP_AFDEMCMC. After that switch point, it uses DEMCMCZS proposals from an
+ * archive. The archive is initialized like DEMCMCZS and is grown throughout
+ * the whole run, including the affine phase, so DEMCMCZS can use the affine
+ * exploration history after handoff.
+ */
+double *AFDEMCMCZS(
+double (MODEL_LIKELIHOOD)(DATA, double *),
+DATA DATA, PARAMETER_INFO PI, MCMC_OPTIONS MCO, MCMC_OUTPUT *MCOUT){
+
+printf("CARDAMOM: Successfully entered AFDEMCMCZS!\n"); fflush(stdout);
+
+/*ERASING PREVIOUS FILE IF APPEND == 0 */
+if(MCO.APPEND==0 && MCO.nWRITE>0){FILE *fileout=fopen(MCO.outfile,"wb");fclose(fileout);}
+
+int NC=MCO.nchains;
+int initialNC=NC;
+int demNC=10;
+if (demNC>initialNC){demNC=initialNC;}
+
+/*DEMCMCZS archive constants, matching DEMCMCZS.c*/
+int M0=10*PI.npars;
+if (M0<NC){M0=NC;}
+int K=10;
+double psnooker=0.10;
+
+int switch_iter=(int)((double)MCO.nOUT*MCO.fADAPT);
+if (switch_iter<0){switch_iter=0;}
+if (switch_iter>MCO.nOUT){switch_iter=MCO.nOUT;}
+
+/*The archive keeps all affine-phase 400-chain history, then only appends the
+ *10 live DEMCMCZS chains after the switch.*/
+int max_affine_appends=switch_iter/K+2;
+int max_demcmczs_appends=(MCO.nOUT-switch_iter)/K+2;
+int maxM=M0+initialNC*max_affine_appends+demNC*max_demcmczs_appends;
+
+double *Z=calloc((size_t)maxM*PI.npars,sizeof(double));
+double *PARS=calloc(PI.npars*NC,sizeof(double));
+double *pars_new=calloc(PI.npars,sizeof(double));
+double *P=calloc(NC,sizeof(double));
+double *BESTPARS=calloc(PI.npars*NC,sizeof(double));
+double *BESTP=calloc(NC,sizeof(double));
+
+int n,nn,M=M0;
+double par;
+
+/*Initialize live chains from PI.parini, same convention as AFDEMCMC/DEMCMCZS.*/
+for (nn=0;nn<NC;nn++){
+for (n=0;n<PI.npars;n++){
+if (MCO.randparini==1 && PI.parfix[n]!=1){
+par=nor2par((double)random()/(double)RAND_MAX,PI.parmin[n],PI.parmax[n]);
+}else{
+par=PI.parini[n+nn*PI.npars];
+if (par>PI.parmax[n] || par<PI.parmin[n]){printf("Warning, prescribed initial parameters are out of range\n");}
+}
+PARS[nn*PI.npars+n]=par;
+Z[nn*PI.npars+n]=par;
+}}
+
+/*Fill the rest of the initial archive with random prior draws, matching DEMCMCZS.c.*/
+for (nn=NC;nn<M0;nn++){
+for (n=0;n<PI.npars;n++){
+if (PI.parfix[n]==1){par=PI.parini[n];}
+else{par=nor2par((double)random()/(double)RAND_MAX,PI.parmin[n],PI.parmax[n]);}
+Z[nn*PI.npars+n]=par;
+}}
+
+oksofar("Established PI.parini - beginning AFDEMCMCZS now");
+
+memcpy(BESTPARS,PARS,PI.npars*NC*sizeof(double));
+
+/*STEP 1 - RUN MODEL WITH INITIAL PARAMETERS*/
+for (nn=0;nn<NC;nn++){
+P[nn]=MODEL_LIKELIHOOD(DATA,&PARS[nn*PI.npars]);
+if (isnan(P[nn])){printf("Warning: MLF generated NaN... treating as -Inf");P[nn]=log(0);}
+if (isinf(P[nn])==-1){printf("WARNING! P(0)=-inf - AFDEMCMCZS may get stuck - if so, please check your initial conditions\n");}
+}
+memcpy(BESTP,P,NC*sizeof(double));
+
+double P_new,lr,gratio;
+int withinrange,wrlocal=0;
+
+COUNTERS N;
+N.ACC=0;
+N.ITER=MCO.nSTART;
+N.ACCLOC=0;
+N.ACCRATE=0;
+
+printf("AFDEMCMCZS: affine phase ends at iteration %d out of %d\n",switch_iter,MCO.nOUT);
+printf("AFDEMCMCZS: switching from %d affine chains to %d DEMCMCZS chains\n",initialNC,demNC);
+
+int activeNC=initialNC;
+int switched_to_demcmczs=0;
+
+/*STEP 2 - BEGIN MCMC*/
+for ( ;N.ITER<MCO.nOUT;N.ITER++){
+
+if (!switched_to_demcmczs && N.ITER>=switch_iter){
+double *PARS_SMALL=calloc(PI.npars*demNC,sizeof(double));
+double *BESTPARS_SMALL=calloc(PI.npars*demNC,sizeof(double));
+double *P_SMALL=calloc(demNC,sizeof(double));
+double *BESTP_SMALL=calloc(demNC,sizeof(double));
+int *selected=calloc(demNC,sizeof(int));
+double *rankP=calloc(initialNC,sizeof(double));
+for (nn=0;nn<initialNC;nn++){rankP[nn]=P[nn];}
+
+int k,ii,best_idx;
+for (k=0;k<demNC;k++){
+best_idx=0;
+double best_val=rankP[0];
+for (ii=1;ii<initialNC;ii++){
+if (rankP[ii]>best_val){best_val=rankP[ii];best_idx=ii;}}
+selected[k]=best_idx;
+P_SMALL[k]=P[best_idx];
+BESTP_SMALL[k]=BESTP[best_idx];
+for (n=0;n<PI.npars;n++){
+PARS_SMALL[k*PI.npars+n]=PARS[best_idx*PI.npars+n];
+BESTPARS_SMALL[k*PI.npars+n]=BESTPARS[best_idx*PI.npars+n];}
+rankP[best_idx]=log(0);
+}
+
+for (k=0;k<demNC;k++){
+P[k]=P_SMALL[k];
+BESTP[k]=BESTP_SMALL[k];
+for (n=0;n<PI.npars;n++){
+PARS[k*PI.npars+n]=PARS_SMALL[k*PI.npars+n];
+BESTPARS[k*PI.npars+n]=BESTPARS_SMALL[k*PI.npars+n];}
+}
+
+printf("AFDEMCMCZS: selected DEMCMCZS live-chain source indices:");
+for (k=0;k<demNC;k++){printf(" %d(%2.1f)",selected[k],P_SMALL[k]);}
+printf("\n");
+
+free(PARS_SMALL);
+free(BESTPARS_SMALL);
+free(P_SMALL);
+free(BESTP_SMALL);
+free(selected);
+free(rankP);
+
+activeNC=demNC;
+switched_to_demcmczs=1;
+}
+
+for (nn=0;nn<activeNC;nn++){
+
+gratio=0;
+if (N.ITER<switch_iter){
+withinrange=STEP_AFDEMCMC(PARS,pars_new,PI,nn,activeNC,&gratio);
+}else{
+if ((double)random()/(double)RAND_MAX<psnooker){
+withinrange=STEP_DEMCMCZ_SNOOKER(&PARS[nn*PI.npars],Z,M,pars_new,PI,&gratio);
+}else{
+withinrange=STEP_DEMCMCZ_PARALLEL(&PARS[nn*PI.npars],Z,M,pars_new,PI);
+}
+}
+
+lr=log((double)random()/(double)RAND_MAX);
+
+if (withinrange==1){
+wrlocal=wrlocal+1;
+P_new=MODEL_LIKELIHOOD(DATA,pars_new);
+}else{
+P_new=log(0);
+}
+if (isnan(P_new)){P_new=log(0);}
+
+if (P_new-P[nn]+gratio>lr || (isinf(P[nn]) && withinrange==1)){
+N.ACC=N.ACC+1;
+for (n=0;n<PI.npars;n++){PARS[n+nn*PI.npars]=pars_new[n];}
+if (P_new>=BESTP[nn]){
+for (n=0;n<PI.npars;n++){BESTPARS[n+nn*PI.npars]=pars_new[n];}
+BESTP[nn]=P_new;}
+P[nn]=P_new;
+}
+}
+
+/*Regularly write results.*/
+if (MCO.nWRITE>0 && (N.ITER % MCO.nWRITE)==0){
+MCMC_OPTIONS MCO_WRITE=MCO;
+MCO_WRITE.nchains=activeNC;
+WRITE_DEMCMC_RESULTS(PARS,PI,MCO_WRITE,N.ITER);}
+
+/*Regularly write restart file.*/
+if (MCO.nWRITE>0 && (N.ITER % 1000)==0){
+MCMC_OPTIONS MCO_WRITE=MCO;
+MCO_WRITE.nchains=activeNC;
+WRITE_DEMCMC_RESTART(PARS,PI,MCO_WRITE,N.ITER);}
+
+/*Append current chain states to the DEMCMCZS archive during both phases.*/
+if ((N.ITER+1) % K==0 && M+activeNC<=maxM){
+for (nn=0;nn<activeNC;nn++){
+for (n=0;n<PI.npars;n++){Z[(M+nn)*PI.npars+n]=PARS[nn*PI.npars+n];}}
+M=M+activeNC;
+}
+
+/*Printing Info*/
+if (MCO.nPRINT>0 && N.ITER % MCO.nPRINT==0){
+printf("%d out of %d iterations (archive size = %d out of %d)\n",N.ITER,MCO.nOUT,M,maxM);
+printf("AFDEMCMCZS phase = %s\n",(N.ITER<switch_iter) ? "affine" : "DEMCMCZS");
+printf("active chains = %d\n",activeNC);
+printf("within range = %2.2f%%\n",wrlocal/((double)(N.ITER+1)*activeNC)*100);
+printf("Local Acceptance rate %5.1f%%\n",100*(double)N.ACC/((double)(N.ITER+1)*activeNC));
+printf("Log Likelihoods: ");
+for (nn=0;nn<activeNC;nn++){printf("%2.1f ",P[nn]);}
+printf("\n");
+}
+
+}
+
+/*filling in MCOUT details*/
+for (n=0;n<PI.npars*activeNC;n++){MCOUT->best_pars[n]=BESTPARS[n];}
+MCOUT->complete=1;
+
+free(BESTPARS);
+free(BESTP);
+free(Z);
+free(PARS);
+free(pars_new);
+free(P);
+printf("AFDEMCMCZS DONE\n");
+
+return 0;
+}

--- a/C/mcmc_fun/MHMCMC/MCMC_FUN/DEMCMCZS.c
+++ b/C/mcmc_fun/MHMCMC/MCMC_FUN/DEMCMCZS.c
@@ -22,7 +22,7 @@
  * which is frozen between appends. This is what allows so few live chains
  * to work well.
  *
- * v1 scope: no restart/append support (MCO.nSTART is not honoured here,
+ * v1 scope: no restart/append support (MCO.nSTART is not honored here,
  * matching DEMCMC.c's current scope).
  * */
 
@@ -35,11 +35,11 @@ if(MCO.APPEND==0 && MCO.nWRITE>0){FILE *fileout=fopen(MCO.outfile,"wb");fclose(f
 
 int NC=MCO.nchains;
 
-/*Algorithm constants (ter Braak & Vrugt 2008 defaults: M0=10*npars, K=10, 10% snooker updates)*/
+/*Algorithm constants, hardcode based on paper sugg. (ter Braak & Vrugt 2008 defaults: M0=10*npars, K=10, 10% snooker updates)*/
 int M0=10*PI.npars;
 if (M0<NC){M0=NC;}
 int K=10;
-double psnooker=0.10;
+double psnooker=0.10; 
 
 /*Z is known to be bounded in size, since nOUT (total generations) is fixed - preallocate rather than realloc*/
 int maxappends=MCO.nOUT/K;
@@ -136,7 +136,7 @@ WRITE_DEMCMC_RESULTS(X,PI,MCO,N.ITER);}
 if (MCO.nWRITE>0 && (N.ITER % 1000)==0){
 WRITE_DEMCMC_RESTART(X,PI,MCO,N.ITER);}
 
-/*Printing Info to Screen*/
+/*Printing Info*/
 if (MCO.nPRINT>0 && N.ITER % MCO.nPRINT==0){
 printf("%d out of %d generations (archive size = %d out of %d)\n",N.ITER,MCO.nOUT,M,maxM);
 printf("within range = %2.2f%%\n",wrlocal/((double)(N.ITER+1)*NC)*100);
@@ -146,7 +146,7 @@ for (nn=0;nn<NC;nn++){printf("%2.1f ",P[nn]);}
 printf("\n");
 }
 
-/*Appending the current chain states to the archive every K generations*/
+/*Appending the current chain states to the archive Z mat. every K generations*/
 if ((N.ITER+1) % K==0 && M+NC<=maxM){
 for (nn=0;nn<NC;nn++){
 for (n=0;n<PI.npars;n++){Z[(M+nn)*PI.npars+n]=X[nn*PI.npars+n];}}

--- a/C/mcmc_fun/MHMCMC/MCMC_FUN/DEMCMCZS.c
+++ b/C/mcmc_fun/MHMCMC/MCMC_FUN/DEMCMCZS.c
@@ -39,7 +39,7 @@ int NC=MCO.nchains;
 int M0=10*PI.npars;
 if (M0<NC){M0=NC;}
 int K=10;
-double psnooker=0.10; 
+double psnooker=0.10;
 
 /*Z is known to be bounded in size, since nOUT (total generations) is fixed - preallocate rather than realloc*/
 int maxappends=MCO.nOUT/K;

--- a/C/mcmc_fun/MHMCMC/MCMC_FUN/DEMCMCZS.c
+++ b/C/mcmc_fun/MHMCMC/MCMC_FUN/DEMCMCZS.c
@@ -1,0 +1,174 @@
+#pragma once
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "../../../math_fun/std.c"
+#include "NORMPARS.c"
+#include "STEP_DEMCMCZS.c"
+#include "WRITE_DEMCMC_RESULTS.c"
+
+/*here including additional functions needed to initialise and clear memory*/
+#include "INITIALIZE_MCMC_OUTPUT.c"
+
+/*DE-MCZS: Differential Evolution Markov Chain sampling difference vectors
+ * from an archive of past states (DE-MCZ, ter Braak 2006), mixed with a 10%
+ * snooker update (ter Braak & Vrugt 2008, Stat Comput). Designed to work
+ * well with very few live chains (default N=3) by exploiting information
+ * from the chains' own past instead of the other live chains.
+ *
+ * Unlike DEMCMC/AFDEMCMC, proposals are NOT drawn from the other live
+ * chains. Instead, an archive Z of past states is grown by appending the
+ * current chain states every K generations; proposals are drawn from Z,
+ * which is frozen between appends. This is what allows so few live chains
+ * to work well.
+ *
+ * v1 scope: no restart/append support (MCO.nSTART is not honoured here,
+ * matching DEMCMC.c's current scope).
+ * */
+
+double *DEMCMCZS(
+double (MODEL_LIKELIHOOD)(DATA, double *),
+DATA DATA, PARAMETER_INFO PI, MCMC_OPTIONS MCO, MCMC_OUTPUT *MCOUT){
+
+/*ERASING PREVIOUS FILE IF APPEND == 0 */
+if(MCO.APPEND==0 && MCO.nWRITE>0){FILE *fileout=fopen(MCO.outfile,"wb");fclose(fileout);}
+
+int NC=MCO.nchains;
+
+/*Algorithm constants (ter Braak & Vrugt 2008 defaults: M0=10*npars, K=10, 10% snooker updates)*/
+int M0=10*PI.npars;
+if (M0<NC){M0=NC;}
+int K=10;
+double psnooker=0.10;
+
+/*Z is known to be bounded in size, since nOUT (total generations) is fixed - preallocate rather than realloc*/
+int maxappends=MCO.nOUT/K;
+int maxM=M0+NC*maxappends;
+
+double *Z=calloc((size_t)maxM*PI.npars,sizeof(double));
+double *X=calloc(PI.npars*NC,sizeof(double));
+double *pars_new=calloc(PI.npars,sizeof(double));
+double *P=calloc(NC,sizeof(double));
+double *BESTPARS=calloc(PI.npars*NC,sizeof(double));
+double *BESTP=calloc(NC,sizeof(double));
+
+int n,nn,M=M0;
+double par;
+
+/*Initializing the first NC rows of the archive (= the live chains) from PI.parini,
+ *same convention as DEMCMC.c/AFDEMCMC.c*/
+for (nn=0;nn<NC;nn++){
+for (n=0;n<PI.npars;n++){
+if (MCO.randparini==1 && PI.parfix[n]!=1){
+par=nor2par((double)random()/(double)RAND_MAX,PI.parmin[n],PI.parmax[n]);
+}else{
+par=PI.parini[n+nn*PI.npars];
+if (par>PI.parmax[n] || par<PI.parmin[n]){printf("Warning, prescribed initial parameters are out of range\n");}
+}
+Z[nn*PI.npars+n]=par;
+X[nn*PI.npars+n]=par;
+}}
+
+/*Initializing the remaining archive rows (NC..M0-1) with a wide random scatter, so the
+ *archive is well-diversified from the start (ter Braak & Vrugt 2008, sect. 2.2)*/
+for (nn=NC;nn<M0;nn++){
+for (n=0;n<PI.npars;n++){
+if (PI.parfix[n]==1){par=PI.parini[n];}
+else{par=nor2par((double)random()/(double)RAND_MAX,PI.parmin[n],PI.parmax[n]);}
+Z[nn*PI.npars+n]=par;
+}}
+
+oksofar("Established PI.parini - beginning DEMCMCZS now");
+
+memcpy(BESTPARS,X,PI.npars*NC*sizeof(double));
+
+/*STEP 1 - RUN MODEL WITH INITIAL PARAMETERS*/
+for (nn=0;nn<NC;nn++){
+P[nn]=MODEL_LIKELIHOOD(DATA,&X[nn*PI.npars]);
+if (isnan(P[nn])){printf("Warning: MLF generated NaN... treating as -Inf");P[nn]=log(0);}
+if (isinf(P[nn])==-1){printf("WARNING! P(0)=-inf - DEMCMCZS may get stuck - if so, please check your initial conditions\n");}
+}
+memcpy(BESTP,P,NC*sizeof(double));
+
+double P_new,lr,gratio;
+int withinrange,wrlocal=0;
+
+COUNTERS N;
+N.ACC=0;N.ITER=0;N.ACCLOC=0;N.ACCRATE=0;
+
+/*STEP 2 - BEGIN MCMC*/
+for (N.ITER=0;N.ITER<MCO.nOUT;N.ITER++){
+
+for (nn=0;nn<NC;nn++){
+
+gratio=0;
+if ((double)random()/(double)RAND_MAX<psnooker){
+withinrange=STEP_DEMCMCZ_SNOOKER(&X[nn*PI.npars],Z,M,pars_new,PI,&gratio);
+}else{
+withinrange=STEP_DEMCMCZ_PARALLEL(&X[nn*PI.npars],Z,M,pars_new,PI);
+}
+
+lr=log((double)random()/(double)RAND_MAX);
+
+if (withinrange==1){
+wrlocal=wrlocal+1;
+P_new=MODEL_LIKELIHOOD(DATA,pars_new);
+}else{
+P_new=log(0);
+}
+if (isnan(P_new)){P_new=log(0);}
+
+if (P_new-P[nn]+gratio>lr || (isinf(P[nn]) && withinrange==1)){
+N.ACC=N.ACC+1;
+for (n=0;n<PI.npars;n++){X[n+nn*PI.npars]=pars_new[n];}
+if (P_new>=BESTP[nn]){
+for (n=0;n<PI.npars;n++){BESTPARS[n+nn*PI.npars]=pars_new[n];}
+BESTP[nn]=P_new;}
+P[nn]=P_new;
+}
+}
+
+/*regularly write results*/
+if (MCO.nWRITE>0 && (N.ITER % MCO.nWRITE)==0){
+WRITE_DEMCMC_RESULTS(X,PI,MCO,N.ITER);}
+
+/*regularly write restart file*/
+if (MCO.nWRITE>0 && (N.ITER % 1000)==0){
+WRITE_DEMCMC_RESTART(X,PI,MCO,N.ITER);}
+
+/*Printing Info to Screen*/
+if (MCO.nPRINT>0 && N.ITER % MCO.nPRINT==0){
+printf("%d out of %d generations (archive size = %d out of %d)\n",N.ITER,MCO.nOUT,M,maxM);
+printf("within range = %2.2f%%\n",wrlocal/((double)(N.ITER+1)*NC)*100);
+printf("Local Acceptance rate %5.1f%%\n",100*(double)N.ACC/((double)(N.ITER+1)*NC));
+printf("Log Likelihoods: ");
+for (nn=0;nn<NC;nn++){printf("%2.1f ",P[nn]);}
+printf("\n");
+}
+
+/*Appending the current chain states to the archive every K generations*/
+if ((N.ITER+1) % K==0 && M+NC<=maxM){
+for (nn=0;nn<NC;nn++){
+for (n=0;n<PI.npars;n++){Z[(M+nn)*PI.npars+n]=X[nn*PI.npars+n];}}
+M=M+NC;
+}
+
+/*END OF WHILE LOOP*/
+}
+
+/*filling in MCOUT details*/
+for (n=0;n<PI.npars*NC;n++){MCOUT->best_pars[n]=BESTPARS[n];}
+MCOUT->complete=1;
+
+free(BESTPARS);
+free(BESTP);
+free(Z);
+free(X);
+free(pars_new);
+free(P);
+printf("DEMCMCZS DONE\n");
+
+return 0;
+
+/*END OF DEMCMCZS*/
+}

--- a/C/mcmc_fun/MHMCMC/MCMC_FUN/DEMCMCZS_WARMUP.c
+++ b/C/mcmc_fun/MHMCMC/MCMC_FUN/DEMCMCZS_WARMUP.c
@@ -1,0 +1,94 @@
+#pragma once
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "NORMPARS.c"
+#include "STEP_DEMCMCZS.c"
+
+/*Self-contained, I/O-free core of DEMCMCZS.c (ter Braak & Vrugt 2008), used by
+ *mode 6 as an intermediate "warm-up" phase between the 400-chain EDC search
+ *and AFDEMCMC production. Runs niter generations on NC chains, overwriting
+ *parini in place with the live chain state at the end. No output writing, no
+ *restart support - this is only ever an intermediate step feeding into a
+ *subsequent sampler, not a saved result in its own right.*/
+void RUN_DEMCMCZS_WARMUP(
+double (MODEL_LIKELIHOOD)(DATA, double *),
+DATA DATA, PARAMETER_INFO PI, int NC, int niter, double *parini){
+
+int M0=10*PI.npars;
+if (M0<NC){M0=NC;}
+int K=10;
+double psnooker=0.10;
+
+int maxappends=niter/K;
+int maxM=M0+NC*maxappends;
+
+double *Z=calloc((size_t)maxM*PI.npars,sizeof(double));
+double *X=calloc(PI.npars*NC,sizeof(double));
+double *pars_new=calloc(PI.npars,sizeof(double));
+double *P=calloc(NC,sizeof(double));
+
+int n,nn,M=M0;
+
+/*seeding the archive's first NC rows (= the live chains) from the caller-supplied parini*/
+for (nn=0;nn<NC;nn++){
+for (n=0;n<PI.npars;n++){
+Z[nn*PI.npars+n]=parini[n+nn*PI.npars];
+X[nn*PI.npars+n]=parini[n+nn*PI.npars];
+}}
+
+/*scattering the remaining archive rows randomly, same as DEMCMCZS.c*/
+for (nn=NC;nn<M0;nn++){
+for (n=0;n<PI.npars;n++){
+if (PI.parfix[n]==1){Z[nn*PI.npars+n]=parini[n];}
+else{Z[nn*PI.npars+n]=nor2par((double)random()/(double)RAND_MAX,PI.parmin[n],PI.parmax[n]);}
+}}
+
+for (nn=0;nn<NC;nn++){
+P[nn]=MODEL_LIKELIHOOD(DATA,&X[nn*PI.npars]);
+if (isnan(P[nn])){P[nn]=log(0);}
+}
+
+double P_new,lr,gratio;
+int withinrange,iter;
+
+for (iter=0;iter<niter;iter++){
+
+for (nn=0;nn<NC;nn++){
+
+gratio=0;
+if ((double)random()/(double)RAND_MAX<psnooker){
+withinrange=STEP_DEMCMCZ_SNOOKER(&X[nn*PI.npars],Z,M,pars_new,PI,&gratio);
+}else{
+withinrange=STEP_DEMCMCZ_PARALLEL(&X[nn*PI.npars],Z,M,pars_new,PI);
+}
+
+lr=log((double)random()/(double)RAND_MAX);
+
+if (withinrange==1){
+P_new=MODEL_LIKELIHOOD(DATA,pars_new);
+}else{
+P_new=log(0);
+}
+if (isnan(P_new)){P_new=log(0);}
+
+if (P_new-P[nn]+gratio>lr || (isinf(P[nn]) && withinrange==1)){
+for (n=0;n<PI.npars;n++){X[n+nn*PI.npars]=pars_new[n];}
+P[nn]=P_new;
+}
+}
+
+/*appending the current chain states to the archive every K generations, same as DEMCMCZS.c*/
+if ((iter+1) % K==0 && M+NC<=maxM){
+for (nn=0;nn<NC;nn++){
+for (n=0;n<PI.npars;n++){Z[(M+nn)*PI.npars+n]=X[nn*PI.npars+n];}}
+M=M+NC;
+}
+
+}
+
+for (nn=0;nn<NC;nn++){
+for (n=0;n<PI.npars;n++){parini[n+nn*PI.npars]=X[nn*PI.npars+n];}}
+
+free(Z);free(X);free(pars_new);free(P);
+}

--- a/C/mcmc_fun/MHMCMC/MCMC_FUN/DREAMZS.c
+++ b/C/mcmc_fun/MHMCMC/MCMC_FUN/DREAMZS.c
@@ -1,0 +1,174 @@
+#pragma once
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "../../../math_fun/std.c"
+#include "NORMPARS.c"
+#include "STEP_DREAMZS.c"
+#include "STEP_DEMCMCZS.c"
+#include "WRITE_DEMCMC_RESULTS.c"
+
+/*here including additional functions needed to initialise and clear memory*/
+#include "INITIALIZE_MCMC_OUTPUT.c"
+
+/*DREAM(ZS)-lite: archive-based DE-MCZS with a DREAM-style crossover mask.
+ *
+ * This keeps the DEMCMCZS archive and snooker mechanics, but the standard
+ * parallel proposal only updates a random subset of parameters. The CR menu is
+ * fixed rather than adaptively weighted, keeping this mode interpretable as a
+ * first-pass DREAM(ZS) experiment.
+ */
+double *DREAMZS(
+double (MODEL_LIKELIHOOD)(DATA, double *),
+DATA DATA, PARAMETER_INFO PI, MCMC_OPTIONS MCO, MCMC_OUTPUT *MCOUT){
+
+printf("CARDAMOM: Successfully entered DREAMZS!\n"); fflush(stdout);
+
+/*ERASING PREVIOUS FILE IF APPEND == 0 */
+if(MCO.APPEND==0 && MCO.nWRITE>0){FILE *fileout=fopen(MCO.outfile,"wb");fclose(fileout);}
+
+int NC=MCO.nchains;
+
+/*Algorithm constants, matching DEMCMCZS where possible.*/
+int M0=10*PI.npars;
+if (M0<NC){M0=NC;}
+int K=10;
+double psnooker=0.10;
+double CRvals[4]={0.1,0.2,0.5,1.0};
+int nCR=4;
+
+/*Z is known to be bounded in size, since nOUT is fixed.*/
+int maxappends=MCO.nOUT/K+1;
+int maxM=M0+NC*maxappends;
+
+double *Z=calloc((size_t)maxM*PI.npars,sizeof(double));
+double *X=calloc(PI.npars*NC,sizeof(double));
+double *pars_new=calloc(PI.npars,sizeof(double));
+double *P=calloc(NC,sizeof(double));
+double *BESTPARS=calloc(PI.npars*NC,sizeof(double));
+double *BESTP=calloc(NC,sizeof(double));
+
+int n,nn,M=M0;
+double par;
+
+/*Initializing the first NC rows of the archive (= the live chains) from PI.parini.*/
+for (nn=0;nn<NC;nn++){
+for (n=0;n<PI.npars;n++){
+if (MCO.randparini==1 && PI.parfix[n]!=1){
+par=nor2par((double)random()/(double)RAND_MAX,PI.parmin[n],PI.parmax[n]);
+}else{
+par=PI.parini[n+nn*PI.npars];
+if (par>PI.parmax[n] || par<PI.parmin[n]){printf("Warning, prescribed initial parameters are out of range\n");}
+}
+Z[nn*PI.npars+n]=par;
+X[nn*PI.npars+n]=par;
+}}
+
+/*Initializing the remaining archive rows with a wide random scatter.*/
+for (nn=NC;nn<M0;nn++){
+for (n=0;n<PI.npars;n++){
+if (PI.parfix[n]==1){par=PI.parini[n];}
+else{par=nor2par((double)random()/(double)RAND_MAX,PI.parmin[n],PI.parmax[n]);}
+Z[nn*PI.npars+n]=par;
+}}
+
+oksofar("Established PI.parini - beginning DREAMZS now");
+
+memcpy(BESTPARS,X,PI.npars*NC*sizeof(double));
+
+/*STEP 1 - RUN MODEL WITH INITIAL PARAMETERS*/
+for (nn=0;nn<NC;nn++){
+P[nn]=MODEL_LIKELIHOOD(DATA,&X[nn*PI.npars]);
+if (isnan(P[nn])){printf("Warning: MLF generated NaN... treating as -Inf");P[nn]=log(0);}
+if (isinf(P[nn])==-1){printf("WARNING! P(0)=-inf - DREAMZS may get stuck - if so, please check your initial conditions\n");}
+}
+memcpy(BESTP,P,NC*sizeof(double));
+
+double P_new,lr,gratio,CR;
+int withinrange,wrlocal=0,nupdate=0,totalupdates=0;
+
+COUNTERS N;
+N.ACC=0;
+N.ITER=MCO.nSTART;
+N.ACCLOC=0;
+N.ACCRATE=0;
+
+/*STEP 2 - BEGIN MCMC*/
+for ( ;N.ITER<MCO.nOUT;N.ITER++){
+
+for (nn=0;nn<NC;nn++){
+
+gratio=0;
+if ((double)random()/(double)RAND_MAX<psnooker){
+withinrange=STEP_DEMCMCZ_SNOOKER(&X[nn*PI.npars],Z,M,pars_new,PI,&gratio);
+nupdate=PI.npars;
+}else{
+int cridx=(int)(((double)random()/((double)RAND_MAX))*nCR);
+if (cridx>=nCR){cridx=nCR-1;}
+CR=CRvals[cridx];
+withinrange=STEP_DREAMZS_PARALLEL(&X[nn*PI.npars],Z,M,pars_new,PI,CR,&nupdate);
+}
+totalupdates=totalupdates+nupdate;
+
+lr=log((double)random()/(double)RAND_MAX);
+
+if (withinrange==1){
+wrlocal=wrlocal+1;
+P_new=MODEL_LIKELIHOOD(DATA,pars_new);
+}else{
+P_new=log(0);
+}
+if (isnan(P_new)){P_new=log(0);}
+
+if (P_new-P[nn]+gratio>lr || (isinf(P[nn]) && withinrange==1)){
+N.ACC=N.ACC+1;
+for (n=0;n<PI.npars;n++){X[n+nn*PI.npars]=pars_new[n];}
+if (P_new>=BESTP[nn]){
+for (n=0;n<PI.npars;n++){BESTPARS[n+nn*PI.npars]=pars_new[n];}
+BESTP[nn]=P_new;}
+P[nn]=P_new;
+}
+}
+
+/*regularly write results*/
+if (MCO.nWRITE>0 && (N.ITER % MCO.nWRITE)==0){
+WRITE_DEMCMC_RESULTS(X,PI,MCO,N.ITER);}
+
+/*regularly write restart file*/
+if (MCO.nWRITE>0 && (N.ITER % 1000)==0){
+WRITE_DEMCMC_RESTART(X,PI,MCO,N.ITER);}
+
+/*Printing Info*/
+if (MCO.nPRINT>0 && N.ITER % MCO.nPRINT==0){
+printf("%d out of %d generations (archive size = %d out of %d)\n",N.ITER,MCO.nOUT,M,maxM);
+printf("within range = %2.2f%%\n",wrlocal/((double)(N.ITER+1)*NC)*100);
+printf("Local Acceptance rate %5.1f%%\n",100*(double)N.ACC/((double)(N.ITER+1)*NC));
+printf("Mean updated dims = %2.2f out of %d\n",(double)totalupdates/((double)(N.ITER+1)*NC),PI.npars);
+printf("Log Likelihoods: ");
+for (nn=0;nn<NC;nn++){printf("%2.1f ",P[nn]);}
+printf("\n");
+}
+
+/*Appending the current chain states to the archive Z mat. every K generations*/
+if ((N.ITER+1) % K==0 && M+NC<=maxM){
+for (nn=0;nn<NC;nn++){
+for (n=0;n<PI.npars;n++){Z[(M+nn)*PI.npars+n]=X[nn*PI.npars+n];}}
+M=M+NC;
+}
+
+}
+
+/*filling in MCOUT details*/
+for (n=0;n<PI.npars*NC;n++){MCOUT->best_pars[n]=BESTPARS[n];}
+MCOUT->complete=1;
+
+free(BESTPARS);
+free(BESTP);
+free(Z);
+free(X);
+free(pars_new);
+free(P);
+printf("DREAMZS DONE\n");
+
+return 0;
+}

--- a/C/mcmc_fun/MHMCMC/MCMC_FUN/HYBRID_AIDE.c
+++ b/C/mcmc_fun/MHMCMC/MCMC_FUN/HYBRID_AIDE.c
@@ -1,0 +1,125 @@
+#pragma once
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "../../../math_fun/std.c"
+#include "NORMPARS.c"
+#include "STEP_HYBRID_AIDE.c"
+#include "WRITE_DEMCMC_RESULTS.c"
+
+/*here including additional functions needed to initialise and clear memory*/
+#include "INITIALIZE_MCMC_OUTPUT.c"
+
+/*HYBRID_AIDE: experimental live-ensemble sampler combining CARDAMOM DEMCMC
+ *translation moves and affine stretch moves inside each proposal. No archive is
+ *used; the proposal source is the live ensemble, like modes 3 and 4.*/
+double *HYBRID_AIDE(
+double (MODEL_LIKELIHOOD)(DATA, double *),
+DATA DATA, PARAMETER_INFO PI, MCMC_OPTIONS MCO, MCMC_OUTPUT *MCOUT){
+
+printf("CARDAMOM: Successfully entered HYBRID_AIDE!\n"); fflush(stdout);
+
+/*ERASING PREVIOUS FILE IF APPEND == 0 */
+if(MCO.APPEND==0 && MCO.nWRITE>0){FILE *fileout=fopen(MCO.outfile,"wb");fclose(fileout);}
+
+int NC=MCO.nchains;
+
+double *P=calloc(NC,sizeof(double));
+double *PARS=calloc(PI.npars*NC,sizeof(double));
+double *pars_new=calloc(PI.npars,sizeof(double));
+double *BESTPARS=calloc(PI.npars*NC,sizeof(double));
+double *BESTP=calloc(NC,sizeof(double));
+
+int n,nn,withinrange,wrlocal=0;
+double par,P_new,gratio,lr;
+
+COUNTERS N;
+N.ACC=0;
+N.ITER=MCO.nSTART;
+N.ACCLOC=0;
+N.ACCRATE=0;
+
+/*Initialize live chains from PI.parini, same convention as other ensemble samplers.*/
+for (nn=0;nn<NC;nn++){
+for (n=0;n<PI.npars;n++){
+if (MCO.randparini==1 && PI.parfix[n]!=1){
+PARS[n+nn*PI.npars]=nor2par((double)random()/(double)RAND_MAX,PI.parmin[n],PI.parmax[n]);
+}else{
+par=PI.parini[n+nn*PI.npars];
+PARS[n+nn*PI.npars]=par;
+if (par>PI.parmax[n] || par<PI.parmin[n]){printf("Warning, prescribed initial parameters are out of range\n");}
+}
+}}
+
+oksofar("Established PI.parini - beginning HYBRID_AIDE now");
+
+memcpy(BESTPARS,PARS,PI.npars*NC*sizeof(double));
+
+/*STEP 1 - RUN MODEL WITH INITIAL PARAMETERS*/
+for (nn=0;nn<NC;nn++){
+P[nn]=MODEL_LIKELIHOOD(DATA,&PARS[nn*PI.npars]);
+if (isnan(P[nn])){printf("Warning: MLF generated NaN... treating as -Inf");P[nn]=log(0);}
+if (isinf(P[nn])==-1){printf("WARNING! P(0)=-inf - HYBRID_AIDE may get stuck - if so, please check your initial conditions\n");}
+}
+memcpy(BESTP,P,NC*sizeof(double));
+
+/*STEP 2 - BEGIN MCMC*/
+for ( ;N.ITER<MCO.nOUT;N.ITER++){
+
+for (nn=0;nn<NC;nn++){
+
+gratio=0;
+withinrange=STEP_HYBRID_AIDE(PARS,pars_new,PI,nn,NC,&gratio);
+
+lr=log((double)random()/(double)RAND_MAX);
+if (withinrange==1){
+wrlocal=wrlocal+1;
+P_new=MODEL_LIKELIHOOD(DATA,pars_new);
+}else{
+P_new=log(0);
+}
+if (isnan(P_new)){P_new=log(0);}
+
+if (P_new-P[nn]+gratio>lr || (isinf(P[nn]) && withinrange==1)){
+N.ACC=N.ACC+1;
+for (n=0;n<PI.npars;n++){PARS[n+nn*PI.npars]=pars_new[n];}
+if (P_new>=BESTP[nn]){
+for (n=0;n<PI.npars;n++){BESTPARS[n+nn*PI.npars]=pars_new[n];}
+BESTP[nn]=P_new;}
+P[nn]=P_new;
+}
+}
+
+/*regularly write results*/
+if (MCO.nWRITE>0 && (N.ITER % MCO.nWRITE)==0){
+WRITE_DEMCMC_RESULTS(PARS,PI,MCO,N.ITER);}
+
+/*regularly write restart file*/
+if (MCO.nWRITE>0 && (N.ITER % 1000)==0){
+WRITE_DEMCMC_RESTART(PARS,PI,MCO,N.ITER);}
+
+/*Printing Info to Screen*/
+if (MCO.nPRINT>0 && N.ITER % MCO.nPRINT==0){
+printf("%d out of %d iterations\n",N.ITER,MCO.nOUT);
+printf("within range = %2.2f%%\n",wrlocal/((double)(N.ITER+1)*NC)*100);
+printf("Local Acceptance rate %5.1f%%\n",100*(double)N.ACC/((double)(N.ITER+1)*NC));
+printf("Log Likelihoods: ");
+for (nn=0;nn<NC;nn++){printf("%2.1f ",P[nn]);}
+printf("\n");
+}
+
+}
+
+/*filling in MCOUT details*/
+for (n=0;n<PI.npars*NC;n++){MCOUT->best_pars[n]=BESTPARS[n];}
+MCOUT->complete=1;
+
+free(BESTPARS);
+free(BESTP);
+free(PARS);
+free(pars_new);
+free(P);
+printf("HYBRID_AIDE DONE\n");
+
+return 0;
+}

--- a/C/mcmc_fun/MHMCMC/MCMC_FUN/HYBRID_AIDE_DEMCMC.c
+++ b/C/mcmc_fun/MHMCMC/MCMC_FUN/HYBRID_AIDE_DEMCMC.c
@@ -1,0 +1,141 @@
+#pragma once
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "../../../math_fun/std.c"
+#include "NORMPARS.c"
+#include "STEP_HYBRID_AIDE.c"
+#include "STEP_DEMCMC.c"
+#include "WRITE_DEMCMC_RESULTS.c"
+
+/*here including additional functions needed to initialise and clear memory*/
+#include "INITIALIZE_MCMC_OUTPUT.c"
+
+/*HYBRID_AIDE_DEMCMC: experimental live-ensemble sampler where fADAPT controls
+ *an initial HYBRID_AIDE phase followed by standard CARDAMOM DEMCMC proposals.
+ *No archive is used; both phases draw proposal information from live chains.*/
+double *HYBRID_AIDE_DEMCMC(
+double (MODEL_LIKELIHOOD)(DATA, double *),
+DATA DATA, PARAMETER_INFO PI, MCMC_OPTIONS MCO, MCMC_OUTPUT *MCOUT){
+
+printf("CARDAMOM: Successfully entered HYBRID_AIDE_DEMCMC!\n"); fflush(stdout);
+
+/*ERASING PREVIOUS FILE IF APPEND == 0 */
+if(MCO.APPEND==0 && MCO.nWRITE>0){FILE *fileout=fopen(MCO.outfile,"wb");fclose(fileout);}
+
+int NC=MCO.nchains;
+
+double *P=calloc(NC,sizeof(double));
+double *PARS=calloc(PI.npars*NC,sizeof(double));
+double *pars_new=calloc(PI.npars,sizeof(double));
+double *BESTPARS=calloc(PI.npars*NC,sizeof(double));
+double *BESTP=calloc(NC,sizeof(double));
+
+int n,nn,withinrange,wrlocal=0;
+double par,P_new,gratio,lr;
+
+COUNTERS N;
+N.ACC=0;
+N.ITER=MCO.nSTART;
+N.ACCLOC=0;
+N.ACCRATE=0;
+
+int switch_iter=(int)((double)MCO.nOUT*MCO.fADAPT);
+if (switch_iter<0){switch_iter=0;}
+if (switch_iter>MCO.nOUT){switch_iter=MCO.nOUT;}
+
+printf("HYBRID_AIDE_DEMCMC: AIDE phase ends at iteration %d out of %d\n",switch_iter,MCO.nOUT);
+
+/*Initialize live chains from PI.parini, same convention as other ensemble samplers.*/
+for (nn=0;nn<NC;nn++){
+for (n=0;n<PI.npars;n++){
+if (MCO.randparini==1 && PI.parfix[n]!=1){
+PARS[n+nn*PI.npars]=nor2par((double)random()/(double)RAND_MAX,PI.parmin[n],PI.parmax[n]);
+}else{
+par=PI.parini[n+nn*PI.npars];
+PARS[n+nn*PI.npars]=par;
+if (par>PI.parmax[n] || par<PI.parmin[n]){printf("Warning, prescribed initial parameters are out of range\n");}
+}
+}}
+
+oksofar("Established PI.parini - beginning HYBRID_AIDE_DEMCMC now");
+
+memcpy(BESTPARS,PARS,PI.npars*NC*sizeof(double));
+
+/*STEP 1 - RUN MODEL WITH INITIAL PARAMETERS*/
+for (nn=0;nn<NC;nn++){
+P[nn]=MODEL_LIKELIHOOD(DATA,&PARS[nn*PI.npars]);
+if (isnan(P[nn])){printf("Warning: MLF generated NaN... treating as -Inf");P[nn]=log(0);}
+if (isinf(P[nn])==-1){printf("WARNING! P(0)=-inf - HYBRID_AIDE_DEMCMC may get stuck - if so, please check your initial conditions\n");}
+}
+memcpy(BESTP,P,NC*sizeof(double));
+
+/*STEP 2 - BEGIN MCMC*/
+for ( ;N.ITER<MCO.nOUT;N.ITER++){
+
+for (nn=0;nn<NC;nn++){
+
+gratio=0;
+if (N.ITER<switch_iter){
+withinrange=STEP_HYBRID_AIDE(PARS,pars_new,PI,nn,NC,&gratio);
+}else{
+/*Use CARDAMOM's standard DEMCMC gamma mixture before STEP_DEMCMC.*/
+PI.stepsize[0]=1 - (1 - 2.38 / sqrt(2 * PI.npars) * 0.1) *
+	(double)(((double)random() / (double)RAND_MAX) < 0.9);
+withinrange=STEP_DEMCMC(PARS,pars_new,PI,nn,NC);
+gratio=0;
+}
+
+lr=log((double)random()/(double)RAND_MAX);
+if (withinrange==1){
+wrlocal=wrlocal+1;
+P_new=MODEL_LIKELIHOOD(DATA,pars_new);
+}else{
+P_new=log(0);
+}
+if (isnan(P_new)){P_new=log(0);}
+
+if (P_new-P[nn]+gratio>lr || (isinf(P[nn]) && withinrange==1)){
+N.ACC=N.ACC+1;
+for (n=0;n<PI.npars;n++){PARS[n+nn*PI.npars]=pars_new[n];}
+if (P_new>=BESTP[nn]){
+for (n=0;n<PI.npars;n++){BESTPARS[n+nn*PI.npars]=pars_new[n];}
+BESTP[nn]=P_new;}
+P[nn]=P_new;
+}
+}
+
+/*regularly write results*/
+if (MCO.nWRITE>0 && (N.ITER % MCO.nWRITE)==0){
+WRITE_DEMCMC_RESULTS(PARS,PI,MCO,N.ITER);}
+
+/*regularly write restart file*/
+if (MCO.nWRITE>0 && (N.ITER % 1000)==0){
+WRITE_DEMCMC_RESTART(PARS,PI,MCO,N.ITER);}
+
+/*Printing Info to Screen*/
+if (MCO.nPRINT>0 && N.ITER % MCO.nPRINT==0){
+printf("%d out of %d iterations\n",N.ITER,MCO.nOUT);
+printf("HYBRID_AIDE_DEMCMC phase = %s\n",(N.ITER<switch_iter) ? "AIDE" : "DEMCMC");
+printf("within range = %2.2f%%\n",wrlocal/((double)(N.ITER+1)*NC)*100);
+printf("Local Acceptance rate %5.1f%%\n",100*(double)N.ACC/((double)(N.ITER+1)*NC));
+printf("Log Likelihoods: ");
+for (nn=0;nn<NC;nn++){printf("%2.1f ",P[nn]);}
+printf("\n");
+}
+
+}
+
+/*filling in MCOUT details*/
+for (n=0;n<PI.npars*NC;n++){MCOUT->best_pars[n]=BESTPARS[n];}
+MCOUT->complete=1;
+
+free(BESTPARS);
+free(BESTP);
+free(PARS);
+free(pars_new);
+free(P);
+printf("HYBRID_AIDE_DEMCMC DONE\n");
+
+return 0;
+}

--- a/C/mcmc_fun/MHMCMC/MCMC_FUN/STEP_DEMCMCZS.c
+++ b/C/mcmc_fun/MHMCMC/MCMC_FUN/STEP_DEMCMCZS.c
@@ -100,6 +100,8 @@ for (n=0;n<PI.npars;n++){pars_new[n]=nor2par(npar[n],PI.parmin[n],PI.parmax[n]);
 /*Metropolis-Hastings correction for the snooker geometry (eq. 4)*/
 gratio[0]=((double)PI.npars-1.0)*log(sqrt(xstarnorm2)/dnorm);}
 
-free(npar);free(nz);free(d);
+free(npar);
+free(nz);
+free(d);
 return withinlim;
 }

--- a/C/mcmc_fun/MHMCMC/MCMC_FUN/STEP_DEMCMCZS.c
+++ b/C/mcmc_fun/MHMCMC/MCMC_FUN/STEP_DEMCMCZS.c
@@ -1,0 +1,105 @@
+#pragma once
+#include <math.h>
+#include <stdlib.h>
+#include "../../../math_fun/randn.c"
+
+/*DE-MCZ parallel direction update (ter Braak & Vrugt 2008, eq. 2): jump along
+ *the difference of two states drawn from the archive Z (rather than from the
+ *other live chains, as in standard DE-MC/STEP_DEMCMC.c)*/
+int STEP_DEMCMCZ_PARALLEL(double *xi, double *Z, int M, double *pars_new, PARAMETER_INFO PI){
+
+int n,r1=-1,r2=-1;
+double rn;
+
+double *npar=calloc(PI.npars,sizeof(double));
+double *nz1=calloc(PI.npars,sizeof(double));
+double *nz2=calloc(PI.npars,sizeof(double));
+
+for (n=0;n<PI.npars;n++){npar[n]=par2nor(xi[n],PI.parmin[n],PI.parmax[n]);}
+
+/*picking two distinct rows of the archive*/
+while (r1==r2){
+r1=ceil((double)random()*M/((double)RAND_MAX))-1;
+r2=ceil((double)random()*M/((double)RAND_MAX))-1;}
+
+/*gamma: standard DE-MC scaling, with an occasional large jump (10% of updates)*/
+double gamma_de=2.38/sqrt(2.0*(double)PI.npars);
+if ((double)random()/(double)RAND_MAX<0.1){gamma_de=1;}
+
+int withinlim=1;
+for (n=0;n<PI.npars;n++){
+rn=randn();
+nz1[n]=par2nor(Z[r1*PI.npars+n],PI.parmin[n],PI.parmax[n]);
+nz2[n]=par2nor(Z[r2*PI.npars+n],PI.parmin[n],PI.parmax[n]);
+npar[n]=npar[n]+gamma_de*(nz1[n]-nz2[n])+0.01*rn;
+if (npar[n]<0 || npar[n]>1){withinlim=0;}
+}
+
+if (withinlim==1){
+for (n=0;n<PI.npars;n++){pars_new[n]=nor2par(npar[n],PI.parmin[n],PI.parmax[n]);}
+}
+
+free(npar);free(nz1);free(nz2);
+return withinlim;
+}
+
+
+/*DE-MC snooker update (ter Braak & Vrugt 2008, eqs. 3-4): propose a step
+ *along the line through the current chain and a reference state z, both
+ *drawn from the archive Z. Requires the (npars-1)*log(.) Metropolis-Hastings
+ *correction returned via gratio, since the proposal is not symmetric.*/
+int STEP_DEMCMCZ_SNOOKER(double *xi, double *Z, int M, double *pars_new, PARAMETER_INFO PI, double *gratio){
+
+int n,rz=-1,r1=-1,r2=-1;
+
+double *npar=calloc(PI.npars,sizeof(double));
+double *nz=calloc(PI.npars,sizeof(double));
+double *d=calloc(PI.npars,sizeof(double));
+
+for (n=0;n<PI.npars;n++){npar[n]=par2nor(xi[n],PI.parmin[n],PI.parmax[n]);}
+
+/*picking three distinct rows: z (the snooker reference line partner) and r1,r2 (for the projection)*/
+while (rz==r1 || rz==r2 || r1==r2){
+rz=ceil((double)random()*M/((double)RAND_MAX))-1;
+r1=ceil((double)random()*M/((double)RAND_MAX))-1;
+r2=ceil((double)random()*M/((double)RAND_MAX))-1;}
+
+double dnorm2=0;
+for (n=0;n<PI.npars;n++){
+nz[n]=par2nor(Z[rz*PI.npars+n],PI.parmin[n],PI.parmax[n]);
+d[n]=npar[n]-nz[n];
+dnorm2=dnorm2+d[n]*d[n];}
+
+gratio[0]=0;
+
+/*Guard against a degenerate (zero-length) snooker line: cannot define a direction, so reject*/
+if (dnorm2<1e-12){
+free(npar);free(nz);free(d);
+return 0;}
+
+double dnorm=sqrt(dnorm2);
+
+/*projecting zR1 and zR2 orthogonally onto the line xi-z*/
+double s1=0,s2=0;
+for (n=0;n<PI.npars;n++){
+s1=s1+(par2nor(Z[r1*PI.npars+n],PI.parmin[n],PI.parmax[n])-nz[n])*d[n]/dnorm;
+s2=s2+(par2nor(Z[r2*PI.npars+n],PI.parmin[n],PI.parmax[n])-nz[n])*d[n]/dnorm;}
+
+/*gamma_s ~ U[1.2,2.2], the randomised snooker step size ter Braak & Vrugt (2008) use as default*/
+double gammas=1.2+((double)random()/(double)RAND_MAX)*1.0;
+
+int withinlim=1;
+double xstarnorm2=0;
+for (n=0;n<PI.npars;n++){
+npar[n]=npar[n]+gammas*(s1-s2)*d[n]/dnorm;
+xstarnorm2=xstarnorm2+(npar[n]-nz[n])*(npar[n]-nz[n]);
+if (npar[n]<0 || npar[n]>1){withinlim=0;}}
+
+if (withinlim==1){
+for (n=0;n<PI.npars;n++){pars_new[n]=nor2par(npar[n],PI.parmin[n],PI.parmax[n]);}
+/*Metropolis-Hastings correction for the snooker geometry (eq. 4)*/
+gratio[0]=((double)PI.npars-1.0)*log(sqrt(xstarnorm2)/dnorm);}
+
+free(npar);free(nz);free(d);
+return withinlim;
+}

--- a/C/mcmc_fun/MHMCMC/MCMC_FUN/STEP_DREAMZS.c
+++ b/C/mcmc_fun/MHMCMC/MCMC_FUN/STEP_DREAMZS.c
@@ -1,0 +1,67 @@
+#pragma once
+#include <math.h>
+#include <stdlib.h>
+#include "../../../math_fun/randn.c"
+
+/*DREAM(ZS)-lite parallel direction update: draw a differential-evolution
+ *direction from the archive, but only apply it to a crossover-selected subset
+ *of parameters. This is the main DREAM-style difference from DEMCMCZS, which
+ *updates every parameter on each parallel proposal.*/
+int STEP_DREAMZS_PARALLEL(double *xi, double *Z, int M, double *pars_new, PARAMETER_INFO PI, double CR, int *nupdate_out){
+
+int n,r1=-1,r2=-1;
+double rn;
+
+if (CR<1.0/(double)PI.npars){CR=1.0/(double)PI.npars;}
+if (CR>1.0){CR=1.0;}
+
+double *npar=calloc(PI.npars,sizeof(double));
+double *nz1=calloc(PI.npars,sizeof(double));
+double *nz2=calloc(PI.npars,sizeof(double));
+int *update=calloc(PI.npars,sizeof(int));
+
+for (n=0;n<PI.npars;n++){npar[n]=par2nor(xi[n],PI.parmin[n],PI.parmax[n]);}
+
+/*picking two distinct rows of the archive*/
+while (r1==r2){
+r1=ceil((double)random()*M/((double)RAND_MAX))-1;
+r2=ceil((double)random()*M/((double)RAND_MAX))-1;}
+
+/*Force at least one updated dimension so low CR values cannot produce a null move.*/
+int force_dim=(int)(((double)random()/((double)RAND_MAX))*PI.npars);
+if (force_dim>=PI.npars){force_dim=PI.npars-1;}
+
+int nupdate=0;
+for (n=0;n<PI.npars;n++){
+if (n==force_dim || (double)random()/(double)RAND_MAX<CR){
+update[n]=1;
+nupdate=nupdate+1;
+}}
+
+/*DREAM uses the number of updated dimensions for the DE scale.*/
+double gamma_de=2.38/sqrt(2.0*(double)nupdate);
+if ((double)random()/(double)RAND_MAX<0.1){gamma_de=1;}
+
+int withinlim=1;
+for (n=0;n<PI.npars;n++){
+rn=randn();
+nz1[n]=par2nor(Z[r1*PI.npars+n],PI.parmin[n],PI.parmax[n]);
+nz2[n]=par2nor(Z[r2*PI.npars+n],PI.parmin[n],PI.parmax[n]);
+if (update[n]==1){
+npar[n]=npar[n]+gamma_de*(nz1[n]-nz2[n])+0.01*rn;
+}
+if (npar[n]<0 || npar[n]>1){withinlim=0;}
+}
+
+if (withinlim==1){
+for (n=0;n<PI.npars;n++){pars_new[n]=nor2par(npar[n],PI.parmin[n],PI.parmax[n]);}
+}
+
+if (nupdate_out!=NULL){nupdate_out[0]=nupdate;}
+
+free(npar);
+free(nz1);
+free(nz2);
+free(update);
+return withinlim;
+}

--- a/C/mcmc_fun/MHMCMC/MCMC_FUN/STEP_HYBRID_AIDE.c
+++ b/C/mcmc_fun/MHMCMC/MCMC_FUN/STEP_HYBRID_AIDE.c
@@ -1,0 +1,75 @@
+#pragma once
+#include <math.h>
+#include <stdlib.h>
+#include "../../../math_fun/randn.c"
+
+/*HYBRID_AIDE proposal: compose a CARDAMOM DEMCMC translation with an affine
+ *stretch move. The DE translation uses the local CARDAMOM gamma convention:
+ *90% small steps (0.1 * textbook gamma) and 10% full difference-vector jumps.*/
+int STEP_HYBRID_AIDE(double *PARS, double *pars_new, PARAMETER_INFO PI, int C, int NC, double *gratio){
+
+int n,j1=C,j2=C,j3=C;
+double rn;
+
+while (j1==C){j1=ceil((double)random()*NC/((double)RAND_MAX))-1;}
+while (j2==C || j2==j1){j2=ceil((double)random()*NC/((double)RAND_MAX))-1;}
+while (j3==C || j3==j1 || j3==j2){j3=ceil((double)random()*NC/((double)RAND_MAX))-1;}
+
+double *xcur=calloc(PI.npars,sizeof(double));
+double *x1=calloc(PI.npars,sizeof(double));
+double *x2=calloc(PI.npars,sizeof(double));
+double *x3=calloc(PI.npars,sizeof(double));
+double *xint=calloc(PI.npars,sizeof(double));
+double *xnew=calloc(PI.npars,sizeof(double));
+
+for (n=0;n<PI.npars;n++){
+xcur[n]=par2nor(PARS[C*PI.npars+n],PI.parmin[n],PI.parmax[n]);
+x1[n]=par2nor(PARS[j1*PI.npars+n],PI.parmin[n],PI.parmax[n]);
+x2[n]=par2nor(PARS[j2*PI.npars+n],PI.parmin[n],PI.parmax[n]);
+x3[n]=par2nor(PARS[j3*PI.npars+n],PI.parmin[n],PI.parmax[n]);
+}
+
+double gamma_de=1 - (1 - 2.38 / sqrt(2.0 * PI.npars) * 0.1) *
+	(double)(((double)random() / (double)RAND_MAX) < 0.9);
+
+double a_gw=1.0+exp(randn());
+double u_z=(double)random()/(double)RAND_MAX;
+double z=pow((u_z*(sqrt(a_gw)-1.0/sqrt(a_gw))+1.0/sqrt(a_gw)),2.0);
+
+int de_first=((double)random()/(double)RAND_MAX>0.5);
+int withinlim=1;
+
+if (de_first){
+/*DEMCMC translation -> affine stretch*/
+for (n=0;n<PI.npars;n++){
+rn=randn();
+xint[n]=xcur[n]+gamma_de*(x2[n]-x1[n])+0.000001*rn;
+xnew[n]=x3[n]+z*(xint[n]-x3[n]);
+}}
+else{
+/*affine stretch -> DEMCMC translation*/
+for (n=0;n<PI.npars;n++){
+rn=randn();
+xint[n]=x3[n]+z*(xcur[n]-x3[n]);
+xnew[n]=xint[n]+gamma_de*(x2[n]-x1[n])+0.000001*rn;
+}}
+
+for (n=0;n<PI.npars;n++){
+if (xnew[n]<0 || xnew[n]>1){withinlim=0;}
+}
+
+gratio[0]=0;
+if (withinlim==1){
+for (n=0;n<PI.npars;n++){pars_new[n]=nor2par(xnew[n],PI.parmin[n],PI.parmax[n]);}
+gratio[0]=((double)PI.npars-1.0)*log(z);
+}
+
+free(xcur);
+free(x1);
+free(x2);
+free(x3);
+free(xint);
+free(xnew);
+
+return withinlim;
+}

--- a/C/projects/CARDAMOM_GENERAL/CARDAMOM_NETCDF_DATA_STRUCTURE.c
+++ b/C/projects/CARDAMOM_GENERAL/CARDAMOM_NETCDF_DATA_STRUCTURE.c
@@ -33,6 +33,7 @@ typedef struct MCMCID_STRUCT{
 double value;
 int nITERATIONS;
 int nPRINT;
+int nWRITE;
 int nSAMPLES;
 int nADAPT;
 int nSAMPLES_EDC_SEARCH;

--- a/C/projects/CARDAMOM_GENERAL/CARDAMOM_READ_NETCDF_DATA.c
+++ b/C/projects/CARDAMOM_GENERAL/CARDAMOM_READ_NETCDF_DATA.c
@@ -405,6 +405,7 @@ MCMCID_STRUCT MCMCID;
 MCMCID.value = ncdf_read_single_double_var(ncid, "MCMCID");
 MCMCID.nITERATIONS = ncdf_read_int_attr(ncid, "MCMCID","nITERATIONS");
 MCMCID.nPRINT = ncdf_read_int_attr(ncid, "MCMCID","nPRINT");
+MCMCID.nWRITE = ncdf_read_int_attr(ncid, "MCMCID","nWRITE");
 MCMCID.nSAMPLES= ncdf_read_int_attr(ncid, "MCMCID","nSAMPLES");
 MCMCID.nSAMPLES_EDC_SEARCH= ncdf_read_int_attr(ncid, "MCMCID","nSAMPLES_EDC_SEARCH");
 MCMCID.nADAPT= ncdf_read_int_attr(ncid, "MCMCID","nADAPT");

--- a/C/projects/CARDAMOM_MDF/CARDAMOM_MDF.c
+++ b/C/projects/CARDAMOM_MDF/CARDAMOM_MDF.c
@@ -17,6 +17,7 @@
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/DEMCMCZS.c"
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/DREAMZS.c"
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/HYBRID_AIDE.c"
+#include "../../mcmc_fun/MHMCMC/MCMC_FUN/HYBRID_AIDE_DEMCMC.c"
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/MHMCMC_119.c"
 #include <time.h>
      
@@ -151,6 +152,7 @@ if (MCOPT.mcmcid==6){MCOPT.nchains=400;}
 if (MCOPT.mcmcid==7){MCOPT.nchains=400;}
 if (MCOPT.mcmcid==8){MCOPT.nchains=400;}
 if (MCOPT.mcmcid==9){MCOPT.nchains=400;}
+if (MCOPT.mcmcid==10){MCOPT.nchains=400;}
 
 
 printf("MDF options structure read successfully");
@@ -288,6 +290,11 @@ case 9:
 printf("CARDAMOM_MDF.c: about to start HYBRID_AIDE (mode 9)\n");
 HYBRID_AIDE(DATA.MLF,DATA,PI,MCOPT,&MCOUT);
 printf("CARDAMOM_MDF.c: completed HYBRID_AIDE (mode 9)\n");
+break;
+case 10:
+printf("CARDAMOM_MDF.c: about to start HYBRID_AIDE_DEMCMC (mode 10 AIDE -> DEMCMC)\n");
+HYBRID_AIDE_DEMCMC(DATA.MLF,DATA,PI,MCOPT,&MCOUT);
+printf("CARDAMOM_MDF.c: completed HYBRID_AIDE_DEMCMC (mode 10)\n");
 break;
 
 /*printf("CARDAMOM_MDF.c: DEMCMC temporarily disconnected, need to de-bug, correct and re-introduce");

--- a/C/projects/CARDAMOM_MDF/CARDAMOM_MDF.c
+++ b/C/projects/CARDAMOM_MDF/CARDAMOM_MDF.c
@@ -13,6 +13,7 @@
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/DEMCMC.c"
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/ADEMCMC.c"
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/AFDEMCMC.c"
+#include "../../mcmc_fun/MHMCMC/MCMC_FUN/DEMCMCZS.c"
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/MHMCMC_119.c"
 #include <time.h>
      
@@ -141,6 +142,7 @@ if (MCOPT.mcmcid==119){MCOPT.nchains=1;}
 if (MCOPT.mcmcid==3){MCOPT.nchains=400;}
 if (MCOPT.mcmcid==4){MCOPT.nchains=400;}
 else if (MCOPT.mcmcid==2){MCOPT.nchains=100;}
+if (MCOPT.mcmcid==5){MCOPT.nchains=3;}
 
 
 printf("MDF options structure read successfully");
@@ -253,6 +255,11 @@ case 4:
 printf("DEBUG: About to call AFDEMCMC...\n"); fflush(stdout);
 AFDEMCMC(DATA.MLF,DATA,PI,MCOPT,&MCOUT);
 printf("DEBUG: Successfully returned from AFDEMCMC!\n"); fflush(stdout);
+break;
+case 5:
+printf("CARDAMOM_MDF.c: about to start DEMCMCZS\n");
+DEMCMCZS(DATA.MLF,DATA,PI,MCOPT,&MCOUT);
+printf("CARDAMOM_MDF.c: completed DEMCMCZS\n");
 break;
 
 /*printf("CARDAMOM_MDF.c: DEMCMC temporarily disconnected, need to de-bug, correct and re-introduce");

--- a/C/projects/CARDAMOM_MDF/CARDAMOM_MDF.c
+++ b/C/projects/CARDAMOM_MDF/CARDAMOM_MDF.c
@@ -142,7 +142,8 @@ if (MCOPT.mcmcid==119){MCOPT.nchains=1;}
 if (MCOPT.mcmcid==3){MCOPT.nchains=400;}
 if (MCOPT.mcmcid==4){MCOPT.nchains=400;}
 else if (MCOPT.mcmcid==2){MCOPT.nchains=100;}
-if (MCOPT.mcmcid==5){MCOPT.nchains=3;}
+if (MCOPT.mcmcid==5){MCOPT.nchains=10;}
+if (MCOPT.mcmcid==6){MCOPT.nchains=400;}
 
 
 printf("MDF options structure read successfully");
@@ -260,6 +261,11 @@ case 5:
 printf("CARDAMOM_MDF.c: about to start DEMCMCZS\n");
 DEMCMCZS(DATA.MLF,DATA,PI,MCOPT,&MCOUT);
 printf("CARDAMOM_MDF.c: completed DEMCMCZS\n");
+break;
+case 6:
+printf("CARDAMOM_MDF.c: about to start AFDEMCMC (mode 6 hybrid production)\n");
+AFDEMCMC(DATA.MLF,DATA,PI,MCOPT,&MCOUT);
+printf("CARDAMOM_MDF.c: completed AFDEMCMC (mode 6)\n");
 break;
 
 /*printf("CARDAMOM_MDF.c: DEMCMC temporarily disconnected, need to de-bug, correct and re-introduce");

--- a/C/projects/CARDAMOM_MDF/CARDAMOM_MDF.c
+++ b/C/projects/CARDAMOM_MDF/CARDAMOM_MDF.c
@@ -13,6 +13,7 @@
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/DEMCMC.c"
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/ADEMCMC.c"
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/AFDEMCMC.c"
+#include "../../mcmc_fun/MHMCMC/MCMC_FUN/AFDEMCMCZS.c"
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/DEMCMCZS.c"
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/MHMCMC_119.c"
 #include <time.h>
@@ -145,6 +146,7 @@ if (MCOPT.mcmcid==4){MCOPT.nchains=400;}
 else if (MCOPT.mcmcid==2){MCOPT.nchains=100;}
 if (MCOPT.mcmcid==5){MCOPT.nchains=10;}
 if (MCOPT.mcmcid==6){MCOPT.nchains=400;}
+if (MCOPT.mcmcid==7){MCOPT.nchains=400;}
 
 
 printf("MDF options structure read successfully");
@@ -267,6 +269,11 @@ case 6:
 printf("CARDAMOM_MDF.c: about to start AFDEMCMC (mode 6 hybrid production)\n");
 AFDEMCMC(DATA.MLF,DATA,PI,MCOPT,&MCOUT);
 printf("CARDAMOM_MDF.c: completed AFDEMCMC (mode 6)\n");
+break;
+case 7:
+printf("CARDAMOM_MDF.c: about to start AFDEMCMCZS (mode 7 affine -> DEMCMCZS production)\n");
+AFDEMCMCZS(DATA.MLF,DATA,PI,MCOPT,&MCOUT);
+printf("CARDAMOM_MDF.c: completed AFDEMCMCZS (mode 7)\n");
 break;
 
 /*printf("CARDAMOM_MDF.c: DEMCMC temporarily disconnected, need to de-bug, correct and re-introduce");

--- a/C/projects/CARDAMOM_MDF/CARDAMOM_MDF.c
+++ b/C/projects/CARDAMOM_MDF/CARDAMOM_MDF.c
@@ -16,6 +16,7 @@
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/AFDEMCMCZS.c"
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/DEMCMCZS.c"
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/DREAMZS.c"
+#include "../../mcmc_fun/MHMCMC/MCMC_FUN/HYBRID_AIDE.c"
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/MHMCMC_119.c"
 #include <time.h>
      
@@ -149,6 +150,7 @@ if (MCOPT.mcmcid==5){MCOPT.nchains=10;}
 if (MCOPT.mcmcid==6){MCOPT.nchains=400;}
 if (MCOPT.mcmcid==7){MCOPT.nchains=400;}
 if (MCOPT.mcmcid==8){MCOPT.nchains=400;}
+if (MCOPT.mcmcid==9){MCOPT.nchains=400;}
 
 
 printf("MDF options structure read successfully");
@@ -281,6 +283,11 @@ case 8:
 printf("CARDAMOM_MDF.c: about to start DREAMZS (mode 8)\n");
 DREAMZS(DATA.MLF,DATA,PI,MCOPT,&MCOUT);
 printf("CARDAMOM_MDF.c: completed DREAMZS (mode 8)\n");
+break;
+case 9:
+printf("CARDAMOM_MDF.c: about to start HYBRID_AIDE (mode 9)\n");
+HYBRID_AIDE(DATA.MLF,DATA,PI,MCOPT,&MCOUT);
+printf("CARDAMOM_MDF.c: completed HYBRID_AIDE (mode 9)\n");
 break;
 
 /*printf("CARDAMOM_MDF.c: DEMCMC temporarily disconnected, need to de-bug, correct and re-introduce");

--- a/C/projects/CARDAMOM_MDF/CARDAMOM_MDF.c
+++ b/C/projects/CARDAMOM_MDF/CARDAMOM_MDF.c
@@ -15,6 +15,7 @@
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/AFDEMCMC.c"
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/AFDEMCMCZS.c"
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/DEMCMCZS.c"
+#include "../../mcmc_fun/MHMCMC/MCMC_FUN/DREAMZS.c"
 #include "../../mcmc_fun/MHMCMC/MCMC_FUN/MHMCMC_119.c"
 #include <time.h>
      
@@ -147,6 +148,7 @@ else if (MCOPT.mcmcid==2){MCOPT.nchains=100;}
 if (MCOPT.mcmcid==5){MCOPT.nchains=10;}
 if (MCOPT.mcmcid==6){MCOPT.nchains=400;}
 if (MCOPT.mcmcid==7){MCOPT.nchains=400;}
+if (MCOPT.mcmcid==8){MCOPT.nchains=400;}
 
 
 printf("MDF options structure read successfully");
@@ -274,6 +276,11 @@ case 7:
 printf("CARDAMOM_MDF.c: about to start AFDEMCMCZS (mode 7 affine -> DEMCMCZS production)\n");
 AFDEMCMCZS(DATA.MLF,DATA,PI,MCOPT,&MCOUT);
 printf("CARDAMOM_MDF.c: completed AFDEMCMCZS (mode 7)\n");
+break;
+case 8:
+printf("CARDAMOM_MDF.c: about to start DREAMZS (mode 8)\n");
+DREAMZS(DATA.MLF,DATA,PI,MCOPT,&MCOUT);
+printf("CARDAMOM_MDF.c: completed DREAMZS (mode 8)\n");
 break;
 
 /*printf("CARDAMOM_MDF.c: DEMCMC temporarily disconnected, need to de-bug, correct and re-introduce");

--- a/C/projects/CARDAMOM_MDF/CARDAMOM_MDF.c
+++ b/C/projects/CARDAMOM_MDF/CARDAMOM_MDF.c
@@ -30,6 +30,7 @@ MCOPT->fADAPT=0.5;
 MCOPT->nOUT=DATA.ncdf_data.MCMCID.nITERATIONS;
 MCOPT->nSTART=0;
 MCOPT->nPRINT=DATA.ncdf_data.MCMCID.nPRINT;
+MCOPT->nWRITE=DATA.ncdf_data.MCMCID.nWRITE;
 MCOPT->minstepsize=DATA.ncdf_data.MCMCID.minstepsize;
 MCOPT->mcmcid=DATA.ncdf_data.MCMCID.value;
 MCOPT->nADAPT=DATA.ncdf_data.MCMCID.nADAPT;
@@ -43,8 +44,8 @@ if (MCOPT->mcmcid==DEFAULT_INT_VAL){MCOPT->mcmcid=119;}
 if (MCOPT->nADAPT==DEFAULT_INT_VAL){MCOPT->nADAPT=100;}
 if (MCOPT->fADAPT==DEFAULT_DOUBLE_VAL){MCOPT->fADAPT=0.05;}
 
-//Derive nWRITE from fields
-MCOPT->nWRITE=MCOPT->nOUT/DATA.ncdf_data.MCMCID.nSAMPLES;
+//Default nWRITE is derived from fields unless the MCMCID nWRITE attribute is set.
+if (MCOPT->nWRITE==DEFAULT_INT_VAL){MCOPT->nWRITE=MCOPT->nOUT/DATA.ncdf_data.MCMCID.nSAMPLES;}
 
 
 printf("**********MCMCOPT SUMMARY*******\n");

--- a/C/projects/CARDAMOM_MDF/MCMC_SETUP/PROJECT_FUN/FIND_EDC_INITIAL_VALUES.c
+++ b/C/projects/CARDAMOM_MDF/MCMC_SETUP/PROJECT_FUN/FIND_EDC_INITIAL_VALUES.c
@@ -25,7 +25,7 @@ int PEDCC,nn;
  *EDCs before ending the search. Because the check is PEDCC>nstartchains,
  *the default value of 10 requires at least 11 passing chains.*/
 int nstartchains=10;
-int multichain_edc_search=(MCOPT_CARDAMOM->mcmcid==3 || MCOPT_CARDAMOM->mcmcid==4 || MCOPT_CARDAMOM->mcmcid==5 || MCOPT_CARDAMOM->mcmcid==6);
+int multichain_edc_search=(MCOPT_CARDAMOM->mcmcid==3 || MCOPT_CARDAMOM->mcmcid==4 || MCOPT_CARDAMOM->mcmcid==5 || MCOPT_CARDAMOM->mcmcid==6 || MCOPT_CARDAMOM->mcmcid==7);
         
         
 MCOPT.APPEND=0;
@@ -43,7 +43,7 @@ MCOPT.nchains=1;
 MCOPT.minstepsize=1e-2;
 
 
-/*Modes 3, 4, 5, and 6 must enter the exact same EDC search: 400-chain
+/*Modes 3, 4, 5, 6, and 7 must enter the exact same EDC search: 400-chain
  *ADEMCMC search options, identical pass threshold, identical sampler call,
  *and the same 400-chain PI->parini allocation path. Mode-specific handoff
  *only happens after the shared search completes.*/
@@ -57,7 +57,7 @@ MCOPT.nchains=400;
 MCOPT.fixedpars=0;
 MCOPT.fADAPT=0;
 /*Rebuild PI->parini to the search size for every multi-chain mode. This keeps
- *modes 3/4/5/6 identical before the first EDC-search random draw.*/
+ *modes 3/4/5/6/7 identical before the first EDC-search random draw.*/
 free(PI->parini);
 PI->parini=calloc(MCOPT.nchains*PI->npars,sizeof(double));}
 
@@ -160,8 +160,8 @@ PI->parini=parini_small;
 MCOPT.nchains=nprod;
 }else{
 /*For modes other than mode 5, keep the full EDC-search ensemble. Mode 6 needs
- *all 400 chains for the warmup/merge block below; modes 3 and 4 hand the same
- *400 chains directly to their production samplers.*/
+ *all 400 chains for the warmup/merge block below; modes 3, 4, and 7 hand the
+ *same 400 chains directly to their production samplers.*/
 for (n=0;n<PI->npars*MCOPT.nchains;n++){
 
 	PI->parini[n]=MCOUT.best_pars[n];
@@ -179,7 +179,7 @@ for (n=0;n<PI->npars*MCOPT.nchains;n++){
  *10 DEMCMCZS-evolved) is what gets handed to AFDEMCMC for production.*/
 if (MCOPT_CARDAMOM->mcmcid==6){
 int nwarm=10;
-int WARMUP_ITERS=350000;
+int WARMUP_ITERS=0; //change back to 350000 TBD 
 
 double *chainP=calloc(MCOPT.nchains,sizeof(double));
 int nn2;

--- a/C/projects/CARDAMOM_MDF/MCMC_SETUP/PROJECT_FUN/FIND_EDC_INITIAL_VALUES.c
+++ b/C/projects/CARDAMOM_MDF/MCMC_SETUP/PROJECT_FUN/FIND_EDC_INITIAL_VALUES.c
@@ -172,14 +172,14 @@ for (n=0;n<PI->npars*MCOPT.nchains;n++){
 /*mode 6: hybrid warmup step. PI->parini now holds all 400 EDC-search-endpoint
  *chains (filled by the generic "else" branch above, same as modes 3/4).
  *Rank them by real likelihood among EDC-passing chains, take the best 10,
- *run those 10 through an intermediate DEMCMCZS phase (a hardcoded 350000
- *iterations), then write the resulting evolved states back into their
+ *optionally run those 10 through an intermediate DEMCMCZS phase, then write
+ *the resulting evolved states back into their
  *original slots - leaving the other 390 EDC-search endpoints untouched.
  *MCOPT.nchains stays at 400: the full mixed ensemble (390 EDC endpoints +
  *10 DEMCMCZS-evolved) is what gets handed to AFDEMCMC for production.*/
 if (MCOPT_CARDAMOM->mcmcid==6){
 int nwarm=10;
-int WARMUP_ITERS=0; //change back to 350000 TBD 
+int WARMUP_ITERS=0; /*0 disables the intermediate DEMCMCZS warmup.*/
 
 double *chainP=calloc(MCOPT.nchains,sizeof(double));
 int nn2;

--- a/C/projects/CARDAMOM_MDF/MCMC_SETUP/PROJECT_FUN/FIND_EDC_INITIAL_VALUES.c
+++ b/C/projects/CARDAMOM_MDF/MCMC_SETUP/PROJECT_FUN/FIND_EDC_INITIAL_VALUES.c
@@ -6,6 +6,7 @@
 #include "../../../../mcmc_fun/MHMCMC/MCMC_FUN/DEMCMC.c"
 #include "../../../../mcmc_fun/MHMCMC/MCMC_FUN/ADEMCMC.c"
 #include "../../../../mcmc_fun/MHMCMC/MCMC_FUN/AFDEMCMC.c"
+#include "../../../../mcmc_fun/MHMCMC/MCMC_FUN/DEMCMCZS_WARMUP.c"
 #include "../../../../math_fun/int_max.c"
 
 int FIND_EDC_INITIAL_VALUES(DATA CARDADATA,PARAMETER_INFO *PI, MCMC_OPTIONS *MCOPT_CARDAMOM){
@@ -108,6 +109,26 @@ free(PI->parini);
 PI->parini=calloc(MCOPT.nchains*PI->npars,sizeof(double));}
 
 
+/*mode 6 (hybrid EDC search -> DEMCMCZS warmup -> AFDEMCMC production): the
+ *EDC search itself is identical to modes 3/4 (400-chain AFDEMCMC search), and
+ *production also uses AFDEMCMC with 400 chains (set in CARDAMOM_MDF.c), so
+ *no PI->parini resize is needed here - it's already allocated at npars*400
+ *by the caller. The hybrid step (best 10 of the 400 -> DEMCMCZS warmup ->
+ *merge back into the 400) happens in a dedicated block after the search
+ *while-loop below, once PI->parini has been filled the same way modes 2/3/4
+ *fill it.*/
+if (MCOPT_CARDAMOM->mcmcid==6){
+MCOPT.mcmcid=6;
+default_int_value(&CARDADATA.ncdf_data.MCMCID.nSAMPLES_EDC_SEARCH ,200000);
+MCOPT.nOUT=CARDADATA.ncdf_data.MCMCID.nSAMPLES_EDC_SEARCH ;
+MCOPT.nPRINT=2000;
+MCOPT.minstepsize=1e-5;
+MCOPT.nchains=400;
+MCOPT.fixedpars=0;
+MCOPT.fADAPT=0;
+MCOUT.best_pars=calloc(MCOPT.nchains*PI->npars,sizeof(double));}
+
+
 
 int OK=INITIALIZE_MCMC_OUTPUT(*PI,&MCOUT,MCOPT);
 printf("C/projects/CARDAMOM_MDF/MCMC_SETUP/PROJECT_FUN/FIND_EDC_INITIAL_VALUES.c: MCOUT structure initialized\n");
@@ -149,6 +170,7 @@ while (PEDC!=0){
         if (MCOPT.mcmcid==3){ADEMCMC(CARDADATA.EMLF,CARDADATA,*PI,MCOPT,&MCOUT);};
         if (MCOPT.mcmcid==4){ADEMCMC(CARDADATA.EMLF,CARDADATA,*PI,MCOPT,&MCOUT);};
         if (MCOPT.mcmcid==5){AFDEMCMC(CARDADATA.EMLF,CARDADATA,*PI,MCOPT,&MCOUT);};
+        if (MCOPT.mcmcid==6){AFDEMCMC(CARDADATA.EMLF,CARDADATA,*PI,MCOPT,&MCOUT);};
 
 	/*if (MCOPT.mcmcid==2){DEMCMC(EMLF,CARDADATA,*PI,MCOPT,&MCOUT);};
 	*/
@@ -185,7 +207,9 @@ printf("EDC no %i; attempts = %i; passes = %i (%2.2f%%);\n",nnn,CARDADATA.EDC_IN
 	//convergence threshold - only a handful need to actually pass; the best
 	//MCOPT_CARDAMOM->nchains of them get selected for production below
 	if (MCOPT.mcmcid==5){if (PEDCC>nstartchains){PEDC=0;}else{PEDC=-1;}}
-	if (MCOPT.mcmcid==2 || MCOPT.mcmcid==3 || MCOPT.mcmcid==4 || MCOPT.mcmcid==5){MCOPT.randparini=0;}
+	//mode 6's search is the same 400-chain AFDEMCMC search as modes 3/4/5
+	if (MCOPT.mcmcid==6){if (PEDCC>nstartchains){PEDC=0;}else{PEDC=-1;}}
+	if (MCOPT.mcmcid==2 || MCOPT.mcmcid==3 || MCOPT.mcmcid==4 || MCOPT.mcmcid==5 || MCOPT.mcmcid==6){MCOPT.randparini=0;}
 	/*Hard coding*/
 	
 	/*in case one EDC missing*/
@@ -230,6 +254,52 @@ for (n=0;n<PI->npars*MCOPT.nchains;n++){
 }
 }
 
+
+/*mode 6: hybrid warmup step. PI->parini now holds all 400 EDC-search-endpoint
+ *chains (filled by the generic "else" branch above, same as modes 2/3/4).
+ *Rank them by real likelihood among EDC-passing chains, take the best 10,
+ *run those 10 through an intermediate DEMCMCZS phase (a hardcoded 350000
+ *iterations), then write the resulting evolved states back into their
+ *original slots - leaving the other 390 EDC-search endpoints untouched.
+ *MCOPT.nchains stays at 400: the full mixed ensemble (390 EDC endpoints +
+ *10 DEMCMCZS-evolved) is what gets handed to AFDEMCMC for production.*/
+if (MCOPT_CARDAMOM->mcmcid==6){
+int nwarm=10;
+int WARMUP_ITERS=350000;
+
+double *chainP=calloc(MCOPT.nchains,sizeof(double));
+int nn2;
+for (nn2=0;nn2<MCOPT.nchains;nn2++){
+double edc_p=CARDADATA.EMLF(CARDADATA, PI->parini + nn2*PI->npars);
+if (edc_p==0){chainP[nn2]=CARDADATA.MLF(CARDADATA, PI->parini + nn2*PI->npars);}
+else{chainP[nn2]=log(0);}
+}
+
+int *warm_idx=calloc(nwarm,sizeof(int));
+int k,nn3;
+for (k=0;k<nwarm;k++){
+int bi=0; double best_val=chainP[0];
+for (nn3=1;nn3<MCOPT.nchains;nn3++){
+if (chainP[nn3]>best_val){best_val=chainP[nn3];bi=nn3;}}
+warm_idx[k]=bi;
+chainP[bi]=log(0);
+}
+free(chainP);
+
+double *parini_warm=calloc(nwarm*PI->npars,sizeof(double));
+for (k=0;k<nwarm;k++){
+for (n=0;n<PI->npars;n++){parini_warm[k*PI->npars+n]=PI->parini[warm_idx[k]*PI->npars+n];}}
+
+oksofar("mode 6: running intermediate DEMCMCZS warmup phase on the best 10 EDC-search chains");
+RUN_DEMCMCZS_WARMUP(CARDADATA.MLF,CARDADATA,*PI,nwarm,WARMUP_ITERS,parini_warm);
+oksofar("mode 6: DEMCMCZS warmup phase complete, merging back into the 400-chain ensemble");
+
+for (k=0;k<nwarm;k++){
+for (n=0;n<PI->npars;n++){PI->parini[warm_idx[k]*PI->npars+n]=parini_warm[k*PI->npars+n];}}
+
+free(parini_warm);
+free(warm_idx);
+}
 
 
 /*Sampling new/more parameters*/

--- a/C/projects/CARDAMOM_MDF/MCMC_SETUP/PROJECT_FUN/FIND_EDC_INITIAL_VALUES.c
+++ b/C/projects/CARDAMOM_MDF/MCMC_SETUP/PROJECT_FUN/FIND_EDC_INITIAL_VALUES.c
@@ -25,7 +25,7 @@ int PEDCC,nn;
  *EDCs before ending the search. Because the check is PEDCC>nstartchains,
  *the default value of 10 requires at least 11 passing chains.*/
 int nstartchains=10;
-int multichain_edc_search=(MCOPT_CARDAMOM->mcmcid==3 || MCOPT_CARDAMOM->mcmcid==4 || MCOPT_CARDAMOM->mcmcid==5 || MCOPT_CARDAMOM->mcmcid==6 || MCOPT_CARDAMOM->mcmcid==7 || MCOPT_CARDAMOM->mcmcid==8 || MCOPT_CARDAMOM->mcmcid==9);
+int multichain_edc_search=(MCOPT_CARDAMOM->mcmcid==3 || MCOPT_CARDAMOM->mcmcid==4 || MCOPT_CARDAMOM->mcmcid==5 || MCOPT_CARDAMOM->mcmcid==6 || MCOPT_CARDAMOM->mcmcid==7 || MCOPT_CARDAMOM->mcmcid==8 || MCOPT_CARDAMOM->mcmcid==9 || MCOPT_CARDAMOM->mcmcid==10);
         
         
 MCOPT.APPEND=0;
@@ -43,7 +43,7 @@ MCOPT.nchains=1;
 MCOPT.minstepsize=1e-2;
 
 
-/*Modes 3, 4, 5, 6, 7, 8, and 9 must enter the exact same EDC search: 400-chain
+/*Modes 3, 4, 5, 6, 7, 8, 9, and 10 must enter the exact same EDC search: 400-chain
  *ADEMCMC search options, identical pass threshold, identical sampler call,
  *and the same 400-chain PI->parini allocation path. Mode-specific handoff
  *only happens after the shared search completes.*/
@@ -57,7 +57,7 @@ MCOPT.nchains=400;
 MCOPT.fixedpars=0;
 MCOPT.fADAPT=0;
 /*Rebuild PI->parini to the search size for every multi-chain mode. This keeps
- *modes 3/4/5/6/7/8/9 identical before the first EDC-search random draw.*/
+ *modes 3/4/5/6/7/8/9/10 identical before the first EDC-search random draw.*/
 free(PI->parini);
 PI->parini=calloc(MCOPT.nchains*PI->npars,sizeof(double));}
 
@@ -160,7 +160,7 @@ PI->parini=parini_small;
 MCOPT.nchains=nprod;
 }else{
 /*For modes other than mode 5, keep the full EDC-search ensemble. Mode 6 needs
- *all 400 chains for the warmup/merge block below; modes 3, 4, 7, 8, and 9 hand the
+ *all 400 chains for the warmup/merge block below; modes 3, 4, 7, 8, 9, and 10 hand the
  *same 400 chains directly to their production samplers.*/
 for (n=0;n<PI->npars*MCOPT.nchains;n++){
 

--- a/C/projects/CARDAMOM_MDF/MCMC_SETUP/PROJECT_FUN/FIND_EDC_INITIAL_VALUES.c
+++ b/C/projects/CARDAMOM_MDF/MCMC_SETUP/PROJECT_FUN/FIND_EDC_INITIAL_VALUES.c
@@ -79,6 +79,35 @@ MCOPT.fADAPT=0;
 MCOUT.best_pars=calloc(MCOPT.nchains*PI->npars,sizeof(double));}
 
 
+/*mode 5 (DEMCMCZS): reuse AFDEMCMC (a proven multi-chain searcher, same as
+ *modes 3/4) for the EDC search rather than DEMCMCZS itself, since EDCs are
+ *hard feasibility constraints, not the smooth-posterior problem DEMCMCZS is
+ *designed for. Uses 400 chains like modes 3/4 - a real production run showed
+ *even 400 chains with a lenient threshold took ~84 minutes to converge here,
+ *so matching production's 3 chains directly would be far too chain-starved.
+ *Since production nchains (e.g. 3) is smaller than the search's 400,
+ *PI->parini (allocated by the caller at only npars*production_nchains) is
+ *temporarily grown to npars*400 for the duration of the search, then shrunk
+ *back down after picking the best production_nchains (by real likelihood,
+ *among EDC-passing chains) - see the selection block just after the while
+ *loop below.*/
+if (MCOPT_CARDAMOM->mcmcid==5){
+MCOPT.mcmcid=5;
+default_int_value(&CARDADATA.ncdf_data.MCMCID.nSAMPLES_EDC_SEARCH ,200000);
+MCOPT.nOUT=CARDADATA.ncdf_data.MCMCID.nSAMPLES_EDC_SEARCH ;
+MCOPT.nPRINT=2000;
+MCOPT.minstepsize=1e-5;
+MCOPT.nchains=400;
+MCOPT.fixedpars=0;
+MCOPT.fADAPT=0;
+//declaring best_pars
+MCOUT.best_pars=calloc(MCOPT.nchains*PI->npars,sizeof(double));
+//growing PI->parini to fit 400 chains for the search (caller only allocated
+//enough for MCOPT_CARDAMOM->nchains) - shrunk back after selection, below
+free(PI->parini);
+PI->parini=calloc(MCOPT.nchains*PI->npars,sizeof(double));}
+
+
 
 int OK=INITIALIZE_MCMC_OUTPUT(*PI,&MCOUT,MCOPT);
 printf("C/projects/CARDAMOM_MDF/MCMC_SETUP/PROJECT_FUN/FIND_EDC_INITIAL_VALUES.c: MCOUT structure initialized\n");
@@ -119,6 +148,7 @@ while (PEDC!=0){
         if (MCOPT.mcmcid==2){DEMCMC(CARDADATA.EMLF,CARDADATA,*PI,MCOPT,&MCOUT);};
         if (MCOPT.mcmcid==3){ADEMCMC(CARDADATA.EMLF,CARDADATA,*PI,MCOPT,&MCOUT);};
         if (MCOPT.mcmcid==4){ADEMCMC(CARDADATA.EMLF,CARDADATA,*PI,MCOPT,&MCOUT);};
+        if (MCOPT.mcmcid==5){AFDEMCMC(CARDADATA.EMLF,CARDADATA,*PI,MCOPT,&MCOUT);};
 
 	/*if (MCOPT.mcmcid==2){DEMCMC(EMLF,CARDADATA,*PI,MCOPT,&MCOUT);};
 	*/
@@ -151,7 +181,11 @@ printf("EDC no %i; attempts = %i; passes = %i (%2.2f%%);\n",nnn,CARDADATA.EDC_IN
 	//Guarantee that at least half of chains have non-zero starting probabilities
 	if (MCOPT.mcmcid==3){if (PEDCC>nstartchains){PEDC=0;}else{PEDC=-1;}}
 	if (MCOPT.mcmcid==4){if (PEDCC>nstartchains){PEDC=0;}else{PEDC=-1;}}
-	if (MCOPT.mcmcid==2 || MCOPT.mcmcid==3 || MCOPT.mcmcid==4 ){MCOPT.randparini=0;}	
+	//mode 5 uses 400 chains for the search (same as 3/4), so use the same
+	//convergence threshold - only a handful need to actually pass; the best
+	//MCOPT_CARDAMOM->nchains of them get selected for production below
+	if (MCOPT.mcmcid==5){if (PEDCC>nstartchains){PEDC=0;}else{PEDC=-1;}}
+	if (MCOPT.mcmcid==2 || MCOPT.mcmcid==3 || MCOPT.mcmcid==4 || MCOPT.mcmcid==5){MCOPT.randparini=0;}
 	/*Hard coding*/
 	
 	/*in case one EDC missing*/
@@ -159,10 +193,41 @@ printf("EDC no %i; attempts = %i; passes = %i (%2.2f%%);\n",nnn,CARDADATA.EDC_IN
 
 }
 
+/*mode 5: pick the best MCOPT_CARDAMOM->nchains (production chain count) chains
+ *out of the 400 searched, ranked by real likelihood among those passing EDCs,
+ *then shrink PI->parini back down to that size - the production DEMCMCZS run
+ *only ever sees this final, small, EDC-satisfying set of starting points.*/
+if (MCOPT_CARDAMOM->mcmcid==5){
+int nprod=MCOPT_CARDAMOM->nchains;
+double *chainP=calloc(MCOPT.nchains,sizeof(double));
+int nn2;
+for (nn2=0;nn2<MCOPT.nchains;nn2++){
+double edc_p=CARDADATA.EMLF(CARDADATA, PI->parini + nn2*PI->npars);
+if (edc_p==0){chainP[nn2]=CARDADATA.MLF(CARDADATA, PI->parini + nn2*PI->npars);}
+else{chainP[nn2]=log(0);}
+}
+
+double *parini_small=calloc(nprod*PI->npars,sizeof(double));
+int k,best_idx;
+for (k=0;k<nprod;k++){
+best_idx=0;
+double best_val=chainP[0];
+for (nn2=1;nn2<MCOPT.nchains;nn2++){
+if (chainP[nn2]>best_val){best_val=chainP[nn2];best_idx=nn2;}}
+for (n=0;n<PI->npars;n++){parini_small[k*PI->npars+n]=PI->parini[best_idx*PI->npars+n];}
+chainP[best_idx]=log(0);
+}
+
+free(chainP);
+free(PI->parini);
+PI->parini=parini_small;
+MCOPT.nchains=nprod;
+}else{
 //Probs would make more sense as a memcpy but I am keeping it like this for now
 for (n=0;n<PI->npars*MCOPT.nchains;n++){
 
 	PI->parini[n]=MCOUT.best_pars[n];
+}
 }
 
 

--- a/C/projects/CARDAMOM_MDF/MCMC_SETUP/PROJECT_FUN/FIND_EDC_INITIAL_VALUES.c
+++ b/C/projects/CARDAMOM_MDF/MCMC_SETUP/PROJECT_FUN/FIND_EDC_INITIAL_VALUES.c
@@ -25,7 +25,7 @@ int PEDCC,nn;
  *EDCs before ending the search. Because the check is PEDCC>nstartchains,
  *the default value of 10 requires at least 11 passing chains.*/
 int nstartchains=10;
-int multichain_edc_search=(MCOPT_CARDAMOM->mcmcid==3 || MCOPT_CARDAMOM->mcmcid==4 || MCOPT_CARDAMOM->mcmcid==5 || MCOPT_CARDAMOM->mcmcid==6 || MCOPT_CARDAMOM->mcmcid==7 || MCOPT_CARDAMOM->mcmcid==8);
+int multichain_edc_search=(MCOPT_CARDAMOM->mcmcid==3 || MCOPT_CARDAMOM->mcmcid==4 || MCOPT_CARDAMOM->mcmcid==5 || MCOPT_CARDAMOM->mcmcid==6 || MCOPT_CARDAMOM->mcmcid==7 || MCOPT_CARDAMOM->mcmcid==8 || MCOPT_CARDAMOM->mcmcid==9);
         
         
 MCOPT.APPEND=0;
@@ -43,7 +43,7 @@ MCOPT.nchains=1;
 MCOPT.minstepsize=1e-2;
 
 
-/*Modes 3, 4, 5, 6, 7, and 8 must enter the exact same EDC search: 400-chain
+/*Modes 3, 4, 5, 6, 7, 8, and 9 must enter the exact same EDC search: 400-chain
  *ADEMCMC search options, identical pass threshold, identical sampler call,
  *and the same 400-chain PI->parini allocation path. Mode-specific handoff
  *only happens after the shared search completes.*/
@@ -57,7 +57,7 @@ MCOPT.nchains=400;
 MCOPT.fixedpars=0;
 MCOPT.fADAPT=0;
 /*Rebuild PI->parini to the search size for every multi-chain mode. This keeps
- *modes 3/4/5/6/7/8 identical before the first EDC-search random draw.*/
+ *modes 3/4/5/6/7/8/9 identical before the first EDC-search random draw.*/
 free(PI->parini);
 PI->parini=calloc(MCOPT.nchains*PI->npars,sizeof(double));}
 
@@ -160,7 +160,7 @@ PI->parini=parini_small;
 MCOPT.nchains=nprod;
 }else{
 /*For modes other than mode 5, keep the full EDC-search ensemble. Mode 6 needs
- *all 400 chains for the warmup/merge block below; modes 3, 4, 7, and 8 hand the
+ *all 400 chains for the warmup/merge block below; modes 3, 4, 7, 8, and 9 hand the
  *same 400 chains directly to their production samplers.*/
 for (n=0;n<PI->npars*MCOPT.nchains;n++){
 

--- a/C/projects/CARDAMOM_MDF/MCMC_SETUP/PROJECT_FUN/FIND_EDC_INITIAL_VALUES.c
+++ b/C/projects/CARDAMOM_MDF/MCMC_SETUP/PROJECT_FUN/FIND_EDC_INITIAL_VALUES.c
@@ -25,7 +25,7 @@ int PEDCC,nn;
  *EDCs before ending the search. Because the check is PEDCC>nstartchains,
  *the default value of 10 requires at least 11 passing chains.*/
 int nstartchains=10;
-int multichain_edc_search=(MCOPT_CARDAMOM->mcmcid==3 || MCOPT_CARDAMOM->mcmcid==4 || MCOPT_CARDAMOM->mcmcid==5 || MCOPT_CARDAMOM->mcmcid==6 || MCOPT_CARDAMOM->mcmcid==7);
+int multichain_edc_search=(MCOPT_CARDAMOM->mcmcid==3 || MCOPT_CARDAMOM->mcmcid==4 || MCOPT_CARDAMOM->mcmcid==5 || MCOPT_CARDAMOM->mcmcid==6 || MCOPT_CARDAMOM->mcmcid==7 || MCOPT_CARDAMOM->mcmcid==8);
         
         
 MCOPT.APPEND=0;
@@ -43,7 +43,7 @@ MCOPT.nchains=1;
 MCOPT.minstepsize=1e-2;
 
 
-/*Modes 3, 4, 5, 6, and 7 must enter the exact same EDC search: 400-chain
+/*Modes 3, 4, 5, 6, 7, and 8 must enter the exact same EDC search: 400-chain
  *ADEMCMC search options, identical pass threshold, identical sampler call,
  *and the same 400-chain PI->parini allocation path. Mode-specific handoff
  *only happens after the shared search completes.*/
@@ -57,7 +57,7 @@ MCOPT.nchains=400;
 MCOPT.fixedpars=0;
 MCOPT.fADAPT=0;
 /*Rebuild PI->parini to the search size for every multi-chain mode. This keeps
- *modes 3/4/5/6/7 identical before the first EDC-search random draw.*/
+ *modes 3/4/5/6/7/8 identical before the first EDC-search random draw.*/
 free(PI->parini);
 PI->parini=calloc(MCOPT.nchains*PI->npars,sizeof(double));}
 
@@ -160,7 +160,7 @@ PI->parini=parini_small;
 MCOPT.nchains=nprod;
 }else{
 /*For modes other than mode 5, keep the full EDC-search ensemble. Mode 6 needs
- *all 400 chains for the warmup/merge block below; modes 3, 4, and 7 hand the
+ *all 400 chains for the warmup/merge block below; modes 3, 4, 7, and 8 hand the
  *same 400 chains directly to their production samplers.*/
 for (n=0;n<PI->npars*MCOPT.nchains;n++){
 

--- a/C/projects/CARDAMOM_MDF/MCMC_SETUP/PROJECT_FUN/FIND_EDC_INITIAL_VALUES.c
+++ b/C/projects/CARDAMOM_MDF/MCMC_SETUP/PROJECT_FUN/FIND_EDC_INITIAL_VALUES.c
@@ -5,25 +5,15 @@
 #include "../../../../mcmc_fun/MHMCMC/MCMC_FUN/MHMCMC_119.c"
 #include "../../../../mcmc_fun/MHMCMC/MCMC_FUN/DEMCMC.c"
 #include "../../../../mcmc_fun/MHMCMC/MCMC_FUN/ADEMCMC.c"
-#include "../../../../mcmc_fun/MHMCMC/MCMC_FUN/AFDEMCMC.c"
 #include "../../../../mcmc_fun/MHMCMC/MCMC_FUN/DEMCMCZS_WARMUP.c"
-#include "../../../../math_fun/int_max.c"
 
 int FIND_EDC_INITIAL_VALUES(DATA CARDADATA,PARAMETER_INFO *PI, MCMC_OPTIONS *MCOPT_CARDAMOM){
 
-/*First: choosing the correct EDC MODEL LIKELIHOOD FUNCTION (EMLF)*/
-
-
     printf("*********made it to here FIND_EDC_INITIAL_VALUES********\n");
 
-//double (*EMLF)(DATA, double *);
-//double (*MLF)(DATA, double *);
-
-
-//EMLF=EDC_DALEC_MLF;
-//MLF=DALEC_MLF;
-
-/*This MCMC is designed to find the best-fit DALEC parameters ONLY*/
+/*This search finds parameter vectors that pass the EDC likelihood before the
+ *main CARDAMOM MCMC starts. The search uses CARDADATA.EMLF; the main sampler
+ *continues to use CARDADATA.MLF after this function returns.*/
 
 MCMC_OPTIONS MCOPT;
 MCMC_OUTPUT MCOUT;
@@ -31,102 +21,45 @@ MCMC_OUTPUT MCOUT;
 
 int PEDCC,nn;
 
-
-//option for mcmcid = 3
+/*For multi-chain EDC searches, require more than this many chains to pass
+ *EDCs before ending the search. Because the check is PEDCC>nstartchains,
+ *the default value of 10 requires at least 11 passing chains.*/
 int nstartchains=10;
+int multichain_edc_search=(MCOPT_CARDAMOM->mcmcid==3 || MCOPT_CARDAMOM->mcmcid==4 || MCOPT_CARDAMOM->mcmcid==5 || MCOPT_CARDAMOM->mcmcid==6);
         
         
 MCOPT.APPEND=0;
-MCOPT.nADAPT=10;/*was 20*/
+MCOPT.nADAPT=10;
 MCOPT.fADAPT=0.5;
-MCOPT.nOUT=1000;/*was 2000*/
-MCOPT.nPRINT=100;/*was*/
+MCOPT.nOUT=1000;
+MCOPT.nPRINT=100;
 MCOPT.nWRITE=0;
 MCOPT.nSTART=0;
-/*randparini = 0*/
-/*this means all PI.parini values must either be given values or entered as -9999*/
 MCOPT.randparini=1;
 MCOPT.returnpars=1;
-/*setting fixedpars option to 1*/
 MCOPT.fixedpars=1;
 MCOPT.mcmcid=119;/*Using metropolis-hastings to find initial parameters*/
 MCOPT.nchains=1;
 MCOPT.minstepsize=1e-2;
 
 
-if (MCOPT_CARDAMOM->mcmcid==3){
+/*Modes 3, 4, 5, and 6 must enter the exact same EDC search: 400-chain
+ *ADEMCMC search options, identical pass threshold, identical sampler call,
+ *and the same 400-chain PI->parini allocation path. Mode-specific handoff
+ *only happens after the shared search completes.*/
+if (multichain_edc_search){
 MCOPT.mcmcid=3;
 default_int_value(&CARDADATA.ncdf_data.MCMCID.nSAMPLES_EDC_SEARCH ,200000);
-MCOPT.nOUT=CARDADATA.ncdf_data.MCMCID.nSAMPLES_EDC_SEARCH ;/*Default =  20000*/
-MCOPT.nPRINT=2000;/*1;was 2000*/
-MCOPT.minstepsize=1e-5;
-MCOPT.nchains=400;
-MCOPT.fixedpars=0;
-MCOPT.fADAPT=0;
-//declaring best_pars
-MCOUT.best_pars=calloc(MCOPT.nchains*PI->npars,sizeof(double));}
-
-
-if (MCOPT_CARDAMOM->mcmcid==4){
-MCOPT.mcmcid=4;
-default_int_value(&CARDADATA.ncdf_data.MCMCID.nSAMPLES_EDC_SEARCH ,200000);
-MCOPT.nOUT=CARDADATA.ncdf_data.MCMCID.nSAMPLES_EDC_SEARCH ;/*Default =  20000*/
-MCOPT.nPRINT=2000;/*1;was 2000*/
-MCOPT.minstepsize=1e-5;
-MCOPT.nchains=400;
-MCOPT.fixedpars=0;
-MCOPT.fADAPT=0;
-//declaring best_pars
-MCOUT.best_pars=calloc(MCOPT.nchains*PI->npars,sizeof(double));}
-
-
-/*mode 5 (DEMCMCZS): reuse AFDEMCMC (a proven multi-chain searcher, same as
- *modes 3/4) for the EDC search rather than DEMCMCZS itself, since EDCs are
- *hard feasibility constraints, not the smooth-posterior problem DEMCMCZS is
- *designed for. Uses 400 chains like modes 3/4 - a real production run showed
- *even 400 chains with a lenient threshold took ~84 minutes to converge here,
- *so matching production's 3 chains directly would be far too chain-starved.
- *Since production nchains (e.g. 3) is smaller than the search's 400,
- *PI->parini (allocated by the caller at only npars*production_nchains) is
- *temporarily grown to npars*400 for the duration of the search, then shrunk
- *back down after picking the best production_nchains (by real likelihood,
- *among EDC-passing chains) - see the selection block just after the while
- *loop below.*/
-if (MCOPT_CARDAMOM->mcmcid==5){
-MCOPT.mcmcid=5;
-default_int_value(&CARDADATA.ncdf_data.MCMCID.nSAMPLES_EDC_SEARCH ,200000);
 MCOPT.nOUT=CARDADATA.ncdf_data.MCMCID.nSAMPLES_EDC_SEARCH ;
 MCOPT.nPRINT=2000;
 MCOPT.minstepsize=1e-5;
 MCOPT.nchains=400;
 MCOPT.fixedpars=0;
 MCOPT.fADAPT=0;
-//declaring best_pars
-MCOUT.best_pars=calloc(MCOPT.nchains*PI->npars,sizeof(double));
-//growing PI->parini to fit 400 chains for the search (caller only allocated
-//enough for MCOPT_CARDAMOM->nchains) - shrunk back after selection, below
+/*Rebuild PI->parini to the search size for every multi-chain mode. This keeps
+ *modes 3/4/5/6 identical before the first EDC-search random draw.*/
 free(PI->parini);
 PI->parini=calloc(MCOPT.nchains*PI->npars,sizeof(double));}
-
-
-/*mode 6 (hybrid EDC search -> DEMCMCZS warmup -> AFDEMCMC production): the
- *EDC search itself is identical to modes 3/4 (400-chain AFDEMCMC search), and
- *production also uses AFDEMCMC with 400 chains (set in CARDAMOM_MDF.c), so
- *no PI->parini resize is needed here - it's already allocated at npars*400
- *by the caller. The hybrid step (best 10 of the 400 -> DEMCMCZS warmup ->
- *merge back into the 400) happens in a dedicated block after the search
- *while-loop below, once PI->parini has been filled the same way modes 2/3/4
- *fill it.*/
-if (MCOPT_CARDAMOM->mcmcid==6){
-MCOPT.mcmcid=6;
-default_int_value(&CARDADATA.ncdf_data.MCMCID.nSAMPLES_EDC_SEARCH ,200000);
-MCOPT.nOUT=CARDADATA.ncdf_data.MCMCID.nSAMPLES_EDC_SEARCH ;
-MCOPT.nPRINT=2000;
-MCOPT.minstepsize=1e-5;
-MCOPT.nchains=400;
-MCOPT.fixedpars=0;
-MCOPT.fADAPT=0;
-MCOUT.best_pars=calloc(MCOPT.nchains*PI->npars,sizeof(double));}
 
 
 
@@ -142,18 +75,11 @@ printf("PI->npars (INSIDE FIND_EDC_INITIAL_VALUES.c)= %d\n",PI->npars);
 
 
 
+for (n=0;n<PI->npars*MCOPT.nchains;n++){PI->parini[n]=DEFAULT_DOUBLE_VAL;}
 for (n=0;n<PI->npars;n++){
 PI->stepsize[n]=0.02;
-/*PI->stepsize[n]=0.00005;*/
-PI->parini[n]=DEFAULT_DOUBLE_VAL;
-PI->parfix[n]=0;
-/*
-if (PI->parini[n]!=-9999 & CARDADATA.edc_random_search<1) {PI->parfix[n]=1;}*/}
+PI->parfix[n]=0;}
 
-
-
-
-/*done*/
 
 double PEDC=log(0);
 int count=0;
@@ -161,19 +87,13 @@ while (PEDC!=0){
 	printf("EDC Attempt no %d\n",count);oksofar("---");
 
 	for (n=0;n<PI->npars;n++){PI->stepsize[n]=0.0005;}
-	/*insert prior value option here!*/
 
 	oksofar("Running short MCMC to find x_{EDC} = 1");
     
 	if (MCOPT.mcmcid==119){MHMCMC_119(CARDADATA.EMLF,CARDADATA,*PI,MCOPT,&MCOUT);};
         if (MCOPT.mcmcid==2){DEMCMC(CARDADATA.EMLF,CARDADATA,*PI,MCOPT,&MCOUT);};
-        if (MCOPT.mcmcid==3){ADEMCMC(CARDADATA.EMLF,CARDADATA,*PI,MCOPT,&MCOUT);};
-        if (MCOPT.mcmcid==4){ADEMCMC(CARDADATA.EMLF,CARDADATA,*PI,MCOPT,&MCOUT);};
-        if (MCOPT.mcmcid==5){AFDEMCMC(CARDADATA.EMLF,CARDADATA,*PI,MCOPT,&MCOUT);};
-        if (MCOPT.mcmcid==6){AFDEMCMC(CARDADATA.EMLF,CARDADATA,*PI,MCOPT,&MCOUT);};
+        if (multichain_edc_search){ADEMCMC(CARDADATA.EMLF,CARDADATA,*PI,MCOPT,&MCOUT);};
 
-	/*if (MCOPT.mcmcid==2){DEMCMC(EMLF,CARDADATA,*PI,MCOPT,&MCOUT);};
-	*/
 	oksofar("Short MCMC complete");
 	for (n=0;n<PI->npars*MCOPT.nchains;n++){PI->parini[n]=MCOUT.best_pars[n];}
 
@@ -187,7 +107,7 @@ while (PEDC!=0){
 	
 	printf("*******\n");
 	printf("*******\n");
-	printf("%i out of %i chains have non-zero prob\n",PEDCC,MCOPT.nchains);
+	printf("%i out of %i chains pass EDCs\n",PEDCC,MCOPT.nchains);
     printf("EDC stats\n");
     for (nnn=0;nnn<CARDADATA.noedcs;nnn++){
         double prcnt=100*(double)CARDADATA.EDC_PASS_COUNTER[nnn]/(double)CARDADATA.EDC_INSTANCE_COUNTER[nnn];
@@ -199,20 +119,12 @@ printf("EDC no %i; attempts = %i; passes = %i (%2.2f%%);\n",nnn,CARDADATA.EDC_IN
 	
 	count=count+1;
 	
-	if (MCOPT.mcmcid==2 && PEDCC>MCOPT.nchains){PEDC=0;}
-	//Guarantee that at least half of chains have non-zero starting probabilities
-	if (MCOPT.mcmcid==3){if (PEDCC>nstartchains){PEDC=0;}else{PEDC=-1;}}
-	if (MCOPT.mcmcid==4){if (PEDCC>nstartchains){PEDC=0;}else{PEDC=-1;}}
-	//mode 5 uses 400 chains for the search (same as 3/4), so use the same
-	//convergence threshold - only a handful need to actually pass; the best
-	//MCOPT_CARDAMOM->nchains of them get selected for production below
-	if (MCOPT.mcmcid==5){if (PEDCC>nstartchains){PEDC=0;}else{PEDC=-1;}}
-	//mode 6's search is the same 400-chain AFDEMCMC search as modes 3/4/5
-	if (MCOPT.mcmcid==6){if (PEDCC>nstartchains){PEDC=0;}else{PEDC=-1;}}
-	if (MCOPT.mcmcid==2 || MCOPT.mcmcid==3 || MCOPT.mcmcid==4 || MCOPT.mcmcid==5 || MCOPT.mcmcid==6){MCOPT.randparini=0;}
-	/*Hard coding*/
+	if (MCOPT.mcmcid==2 && PEDCC>=MCOPT.nchains){PEDC=0;}
+	if (multichain_edc_search){if (PEDCC>nstartchains){PEDC=0;}else{PEDC=-1;}}
+	if (MCOPT.mcmcid==2 || multichain_edc_search){MCOPT.randparini=0;}
 	
-	/*in case one EDC missing*/
+	/*For single-chain MH search, periodically restart from priors if no
+	 *EDC-passing point has been found.*/
 	if (MCOPT.mcmcid==119 && PEDC!=0 && count%3==0){for (n=0;n<PI->npars;n++){PI->parini[n]=CARDADATA.parpriors[n];}}
 
 }
@@ -247,7 +159,9 @@ free(PI->parini);
 PI->parini=parini_small;
 MCOPT.nchains=nprod;
 }else{
-//Probs would make more sense as a memcpy but I am keeping it like this for now
+/*For modes other than mode 5, keep the full EDC-search ensemble. Mode 6 needs
+ *all 400 chains for the warmup/merge block below; modes 3 and 4 hand the same
+ *400 chains directly to their production samplers.*/
 for (n=0;n<PI->npars*MCOPT.nchains;n++){
 
 	PI->parini[n]=MCOUT.best_pars[n];
@@ -256,7 +170,7 @@ for (n=0;n<PI->npars*MCOPT.nchains;n++){
 
 
 /*mode 6: hybrid warmup step. PI->parini now holds all 400 EDC-search-endpoint
- *chains (filled by the generic "else" branch above, same as modes 2/3/4).
+ *chains (filled by the generic "else" branch above, same as modes 3/4).
  *Rank them by real likelihood among EDC-passing chains, take the best 10,
  *run those 10 through an intermediate DEMCMCZS phase (a hardcoded 350000
  *iterations), then write the resulting evolved states back into their
@@ -302,23 +216,7 @@ free(warm_idx);
 }
 
 
-/*Sampling new/more parameters*/
-
-	/*
-	for (n=0;n<PI->npars;n++){printf("%8.6f  ",PI->parini[n]);}printf("\n");
-	printf("EDC Probability of starting parameters = %4.4f\n",EMLF(CARDADATA, PI->parini));
-	printf("Probability of starting parameters = %4.4f\n",CARDADATA.MLF(CARDADATA, PI->parini));
-	*/
-	/*for (n=0;n<PI->npars;n++){PI->stepsize[n]=0.01;}*/
-	
-	/*SOON-TO-BE-OBSOLETE: resetting fixed pars to zero for main r*/
-	//for (n=0;n<PI->npars;n++){PI->parfix[n]=0;}
-	//THIS WAS MOVED TO MCMC_MODULES!
-
 /*clearing MCOUT fields*/
 free(MCOUT.best_pars);
-/*Done either (a) reading parameters from file, or (b) sampling parameters
-*/
 
 return 0;}
-

--- a/PYTHON/CARDAMOM_WRITE_CBF_NC_FILE.py
+++ b/PYTHON/CARDAMOM_WRITE_CBF_NC_FILE.py
@@ -122,7 +122,7 @@ def create_cardamom_structure():
         'EDC': {'dims': (), 'data': 1.0, 'attrs': {}},
         'MCMCID': {
             'dims': (), 'data': 3.0,
-            'attrs': {'nITERATIONS': 500000.0, 'nSAMPLES': 10.0, 'nPRINT': 1000.0, 'seed_number': 0.0}
+            'attrs': {'nITERATIONS': 500000.0, 'nSAMPLES': 10.0, 'nPRINT': 1000.0, 'nWRITE': -9999.0, 'seed_number': 0.0}
         },
         'GPPunc': {'dims': ('time_dim',), 'data': np.full(240, np.nan), 'attrs': {'_FillValue': fill_value}},
     }

--- a/doc/markdown_manuals/MCMC_IN_CARDAMOM_OVERVIEW.md
+++ b/doc/markdown_manuals/MCMC_IN_CARDAMOM_OVERVIEW.md
@@ -1,4 +1,4 @@
-# MCMC in CARDAMOM overview
+# MCMC in CARDAMOM Overview
 
 CARDAMOM uses the `MCMCID` variable in the CBF NetCDF input file to select the
 MCMC algorithm used during model-data fusion. MCMC options are stored as
@@ -16,22 +16,7 @@ Common `MCMCID` attributes include:
 | `nSAMPLES_EDC_SEARCH` | Number of iterations used in the EDC initial-condition search. |
 | `seed_number` | Random seed for deterministic/reproducible MCMC initialization and runs. |
 
-## MCMC workflow
-
-CARDAMOM MCMC runs follow the same broad workflow:
-
-1. Read the CBF NetCDF file and `MCMCID` settings.
-2. Set the random seed from `seed_number`, using zero if no seed is provided.
-3. Search for parameter vectors that satisfy the EDCs.
-4. Hand the EDC-passing parameter vectors to the selected MCMC mode.
-5. Run production MCMC for `nITERATIONS` iterations.
-6. Write output every `nWRITE` iterations.
-7. Periodically write a `START` file that can be used to resume a run.
-
-The EDC search and production sampler are separate phases. `nWRITE` controls
-production output spacing, not EDC-search output.
-
-## EDC initial-condition search
+## EDC Initial-Condition Search
 
 Before production MCMC, CARDAMOM searches for parameter vectors that satisfy
 EDCs. Modes 3-10 use the same deterministic 400-chain EDC search before
@@ -43,167 +28,245 @@ For multi-chain EDC searches, CARDAMOM currently stops after more than 10 chains
 pass EDCs. Because the code checks `PEDCC > nstartchains` and `nstartchains=10`,
 this means at least 11 chains must pass EDCs before the search ends.
 
-## MCMC modes
+## MCMC Modes
 
-The CARDAMOM MDF executable currently dispatches the following MCMC modes:
+| MCMCID | Production sampler | Chains after EDC handoff | Archive | Main proposal behavior |
+| --- | --- | --- | --- | --- |
+| 2 | `DEMCMC` | 100 | No | Standard live-chain differential evolution MCMC. |
+| 3 | `ADEMCMC` | 400 | No | `fADAPT` controls an initial `STEP_ADEMCMC` phase, then switches to `STEP_DEMCMC`. |
+| 4 | `AFDEMCMC` | 400 | No | `fADAPT` controls an initial affine/stretch phase, then switches to `STEP_DEMCMC`. |
+| 5 | `DEMCMCZS` | Top 10 EDC-passing chains | Yes | Archive-based differential evolution proposals plus snooker updates. |
+| 6 | `AFDEMCMC` | 400 | Warmup only | Keeps all 400 EDC endpoints; can optionally warm up the best 10 with DEMCMCZS before AFDEMCMC production. |
+| 7 | `AFDEMCMCZS` | 400 affine chains, then top 10 DEMCMCZS chains | Yes | `fADAPT` controls affine phase length, then active chains switch to DEMCMCZS using archive history. |
+| 8 | `DREAMZS` | 400 | Yes | DREAMZS-lite archive proposals with crossover/subspace updates plus snooker updates. |
+| 9 | `HYBRID_AIDE` | 400 | No | Each proposal combines CARDAMOM DEMCMC translation with affine/stretch moves. |
+| 10 | `HYBRID_AIDE_DEMCMC` | 400 | No | `fADAPT` controls an initial HYBRID_AIDE phase, then switches to standard CARDAMOM DEMCMC. |
 
-| MCMCID | Status | Production sampler | Chains after EDC handoff | Archive | Main proposal behavior |
-| --- | --- | --- | --- | --- | --- |
-| 119 | Existing/special | `MHMCMC_119` | 1 | No | Single-chain adaptive Metropolis-Hastings sampler. |
-| 2 | Existing | `DEMCMC` | 100 | No | Standard live-chain differential evolution MCMC. |
-| 3 | Existing | `ADEMCMC` | 400 | No | `fADAPT` controls an initial `STEP_ADEMCMC` phase, then switches to `STEP_DEMCMC`. |
-| 4 | Existing | `AFDEMCMC` | 400 | No | `fADAPT` controls an initial affine/stretch phase, then switches to `STEP_DEMCMC`. |
-| 5 | Added/experimental | `DEMCMCZS` | Top 10 EDC-passing chains | Yes | Archive-based differential evolution proposals plus snooker updates. |
-| 6 | Added/experimental | `AFDEMCMC` | 400 | Warmup only | Keeps all 400 EDC endpoints; can optionally warm up the best 10 with DEMCMCZS before AFDEMCMC production. |
-| 7 | Added/experimental | `AFDEMCMCZS` | 400 affine chains, then top 10 DEMCMCZS chains | Yes | `fADAPT` controls affine phase length, then active chains switch to DEMCMCZS using archive history. |
-| 8 | Added/experimental | `DREAMZS` | 400 | Yes | DREAMZS-lite archive proposals with crossover/subspace updates plus snooker updates. |
-| 9 | Added/experimental | `HYBRID_AIDE` | 400 | No | Each proposal combines CARDAMOM DEMCMC translation with affine/stretch moves. |
-| 10 | Added/experimental | `HYBRID_AIDE_DEMCMC` | 400 | No | `fADAPT` controls an initial HYBRID_AIDE phase, then switches to standard CARDAMOM DEMCMC. |
+## Recommended CBF MCMCID Settings for Comparing Methods
 
-## Proposal families
+MCMC settings are stored as NetCDF attributes on the `MCMCID` variable in the CBF file. The most important attributes to set for clean sampler comparisons are:
 
-Most multi-chain CARDAMOM MCMC modes are built from two proposal ideas:
-DEMCMC moves and affine/stretch moves. The different modes mainly change how
-these proposals are combined, when the sampler switches between them, and
-whether previous samples are stored in an archive.
+| Attribute | Recommended use |
+| --- | --- |
+| `MCMCID` | Selects the sampler mode. |
+| `nITERATIONS` | Set to the desired production run length. |
+| `nWRITE` | Set explicitly for comparison runs so output frequency is standardized. |
+| `nPRINT` | Set to a reasonable progress interval. |
+| `fADAPT` | Set for sequential hybrid modes that switch proposal behavior during the run. |
+| `seed_number` | Keep fixed across comparison runs for reproducible initialization. |
 
-Mode 119 is the exception. It is the older single-chain adaptive
-Metropolis-Hastings path rather than a multi-chain ensemble method.
+For clean comparisons, use the same values of `nITERATIONS`, `nWRITE`, `nPRINT`, `fADAPT`, and `seed_number` unless the purpose of the experiment is to test one of those settings directly.
 
-### Single-chain adaptive Metropolis-Hastings
+Example recommended comparison setup:
 
-The mode 119 sampler is the older single-chain adaptive Metropolis-Hastings
-path. It proposes from the current parameter vector, adapts proposal covariance
-during the adaptation portion of the run, and writes one chain.
+```text
+nITERATIONS = 350000
+nWRITE = 500
+nPRINT = 500
+fADAPT = 0.3
+seed_number = fixed across runs
+```
 
-### DEMCMC
+With this setup, each run writes output every 500 production iterations. This makes trace plots and chain-level diagnostics easier to compare across modes.
 
-DEMCMC proposes movement along the difference between two other live chains:
+### Recommended Settings for Routine Runs
+
+For routine science runs, use mode 9 with 350,000 MCMC iterations. Mode 9 has
+shown similar behavior to mode 4 while requiring roughly half the wall time for
+the same number of iterations.
+
+| Setting | Recommended value |
+| --- | --- |
+| `MCMCID` | `9` |
+| `nITERATIONS` | `350000` |
+| `nSAMPLES` | `2000` |
+| `nWRITE` | `175` |
+| `nPRINT` | `1000` |
+| `nSAMPLES_EDC_SEARCH` | `200000` |
+| `seed_number` | Set explicitly for reproducibility. |
+
+Mode 4 remains the conservative fallback option.
+
+| Setting | Recommended value |
+| --- | --- |
+| `MCMCID` | `4` |
+| `nITERATIONS` | `350000` |
+| `nSAMPLES` | `2000` |
+| `nWRITE` | `175` |
+| `nPRINT` | `1000` |
+| `nSAMPLES_EDC_SEARCH` | `200000` |
+| `seed_number` | Set explicitly for reproducibility. |
+
+### Choosing `fADAPT`
+
+For modes with a phase switch, `fADAPT` controls the fraction of production iterations spent in the first proposal phase.
+
+For example, with:
+
+```text
+nITERATIONS = 350000
+fADAPT = 0.3
+```
+
+the first phase lasts:
+
+```text
+0.3 * 350000 = 105000 iterations
+```
+
+Mode-specific interpretation:
+
+```text
+Mode 4: first 105000 iterations use affine/stretch proposals, then DEMCMC
+Mode 7: first 105000 iterations use affine/stretch proposals, then DEMCMCZS
+Mode 10: first 105000 iterations use HYBRID_AIDE, then DEMCMC
+```
+
+## Proposal Building Blocks and Hybrid Modes
+
+Most of the MCMC modes in this branch are built from two main population-based proposal families: affine/stretch proposals and differential-evolution proposals.
+
+### Affine/Stretch Proposals
+
+Affine-style proposals move one chain relative to another live chain in the ensemble:
+
+```text
+new = partner + z * (current - partner)
+```
+
+where `z` is a random stretch factor. This proposal is useful when the posterior has elongated or correlated geometry, because the move is defined using the shape of the current ensemble rather than a fixed coordinate-wise step size.
+
+The affine proposal uses the Hastings correction:
+
+```text
+(npars - 1) * log(z)
+```
+
+### DEMCMC Proposals
+
+DEMCMC proposes movement using the difference between two other live chains:
 
 ```text
 new = current + gamma * (chain_a - chain_b) + noise
 ```
 
-CARDAMOM's standard `DEMCMC` gamma convention is:
+This allows the sampler to use the scale and orientation of the ensemble to generate jumps. CARDAMOM's standard `DEMCMC` gamma convention is:
 
 ```text
 90% of proposals: gamma = 0.1 * 2.38 / sqrt(2 * npars)
 10% of proposals: gamma = 1.0
 ```
 
-This is the core differential-evolution proposal used directly in mode 2 and
-used after the initial phase in modes 3, 4, and 10.
+### Archive-Based DEMCMCZS Proposals
 
-### Affine/stretch
+DEMCMCZS extends DEMCMC by drawing difference vectors from an archive `Z` of previous chain states rather than only from the current live ensemble. This can make proposals cheaper and more diverse, especially when running with fewer active chains. DEMCMCZS also includes occasional snooker proposals.
 
-Affine ensemble proposals move one chain relative to another live chain using a
-stretch factor. This proposal is useful when parameters are correlated because
-the ensemble geometry helps choose directions and scales.
+### DREAMZS-lite Proposals
 
-```text
-new = chain_ref + z * (current - chain_ref)
-```
+DREAMZS-lite uses the DEMCMCZS archive structure but adds crossover/subspace updates. This means each proposal can update only a subset of parameters rather than always moving the full parameter vector.
 
-The affine proposal has a non-symmetric proposal density, so CARDAMOM applies
-the affine Hastings correction:
+### Sequential Hybrid Modes
+
+Sequential hybrid modes use one proposal family during an early phase of the run and then switch to another proposal family later. The switch point is controlled by `fADAPT`.
+
+For example:
 
 ```text
-(npars - 1) * log(z)
+Mode 4: affine/stretch phase -> DEMCMC phase
+Mode 7: affine/stretch phase -> DEMCMCZS phase
+Mode 10: HYBRID_AIDE phase -> DEMCMC phase
 ```
 
-where `z` is the stretch factor. This correction is required so that the
-proposal preserves detailed balance.
+These modes are useful for testing whether one proposal is better for burn-in while another is better for production sampling.
 
-This is the core affine proposal used directly in modes 4, 6, and 7, and used
-as one part of the hybrid AIDE proposal in modes 9 and 10.
+### Mixed-Kernel Hybrid Modes
 
-### Derived modes
+Mixed-kernel modes combine proposal mechanisms inside the production sampler rather than only switching once between phases.
 
-The remaining multi-chain modes are combinations or extensions of DEMCMC and
-affine/stretch proposals:
+For example:
 
-| Method | Derived from | Description |
-| --- | --- | --- |
-| `ADEMCMC` | DEMCMC | Uses an adaptive differential-evolution-style proposal during the first `fADAPT` fraction of mode 3, then switches to DEMCMC. |
-| `AFDEMCMC` | Affine/stretch + DEMCMC | Uses affine/stretch proposals during the first `fADAPT` fraction of mode 4, then switches to DEMCMC. |
-| `DEMCMCZS` | DEMCMC | Uses archive differences from `Z` instead of only the current live ensemble, with occasional snooker proposals. |
-| `AFDEMCMCZS` | Affine/stretch + DEMCMCZS | Starts with affine/stretch proposals, then switches to archive-based DEMCMCZS proposals. |
-| `DREAMZS-lite` | DEMCMCZS | Adds crossover/subspace updates so some proposals update only a subset of parameters. |
-| `HYBRID_AIDE` | Affine/stretch + DEMCMC | Composes a DEMCMC translation with an affine/stretch move in a single proposal. |
-| `HYBRID_AIDE_DEMCMC` | HYBRID_AIDE + DEMCMC | Uses HYBRID_AIDE for the first `fADAPT` fraction, then switches to DEMCMC. |
+```text
+Mode 5: DEMCMCZS archive proposals + snooker proposals
+Mode 8: DREAMZS-lite archive proposals + crossover/subspace updates + snooker proposals
+Mode 9: HYBRID_AIDE, which combines DEMCMC translation with affine/stretch movement in each proposal
+```
 
-The archive-based modes, `DEMCMCZS` and `DREAMZS-lite`, are still DEMCMC-family
-methods. They differ from standard DEMCMC because proposal differences can be
-drawn from previous samples stored in `Z`, not only from the current live
-ensemble.
-
-The AIDE-family modes combine the two core proposal ideas. In `HYBRID_AIDE`,
-each chain independently chooses one of two proposal orderings:
+HYBRID_AIDE is the most direct mixed-kernel proposal. Each proposal composes a DEMCMC translation with an affine stretch move, using one of two possible orderings:
 
 ```text
 DEMCMC translation -> affine stretch
 affine stretch -> DEMCMC translation
 ```
 
-The DEMCMC translation uses CARDAMOM's standard DEMCMC gamma convention. The
-affine part uses the affine Hastings correction:
+## Adding a new MCMC mode
 
-```text
-(npars - 1) * log(z)
-```
+As previously stated, MCMC modes in CARDAMOM are selected through the `MCMCID` value in the CBF
+NetCDF file. Adding a new mode usually requires changes in two places: the MDF
+driver that dispatches the selected sampler, and the MCMC function files that
+implement the proposal logic.
 
-## Suggested settings
+### Main files to update
 
-For standard mode comparisons, change only the settings required to select the
-mode or proposal split. Keep all other settings fixed:
-
-| Setting | Suggested value |
+| File | What to change |
 | --- | --- |
-| `seed_number` | Same value across all compared runs. |
-| `nSAMPLES_EDC_SEARCH` | Same value across all compared runs. |
-| `nITERATIONS` | Same value across all compared runs. |
-| `nWRITE` | Set explicitly, especially for early-chain diagnostics. |
-| `nPRINT` | Same value across all compared runs. |
-| CBF data and priors | Identical except for intentional `MCMCID` settings. |
-| Executable | Same compiled executable. |
-| `START` file | Avoid unintended reuse when testing EDC behavior. |
+| `C/projects/CARDAMOM_MDF/CARDAMOM_MDF.c` | Include the new sampler file, assign the chain count for the new `MCMCID`, and add a `case` in the MCMC dispatcher. |
+| `C/projects/CARDAMOM_MDF/MCMC_SETUP/PROJECT_FUN/FIND_EDC_INITIAL_VALUES.c` | Decide how the new mode should receive EDC-passing initial chains. For fair comparisons, new multi-chain modes should usually use the same deterministic 400-chain EDC search as modes 3-10. |
+| `C/mcmc_fun/MHMCMC/MCMC_FUN/<NEW_MODE>.c` | Implement the production sampler loop. This usually handles chain state, likelihood calls, acceptance, output writing, and restart writing. |
+| `C/mcmc_fun/MHMCMC/MCMC_FUN/STEP_<NEW_MODE>.c` | Optional but preferred if the proposal step is complex. Keeps proposal construction separate from the sampler loop. |
+| `PYTHON/CARDAMOM_WRITE_CBF_NC_FILE.py` | Update only if the new mode needs new CBF attributes or defaults. |
 
-If `nWRITE` is unset, CARDAMOM derives it from:
+### A Brief Implementation checklist
 
-```text
-nITERATIONS / nSAMPLES
-```
+1. Pick an unused `MCMCID`.
 
-This is convenient for standard output, but explicit `nWRITE` is preferred when
-the goal is to compare early chain behavior.
+2. Add the sampler include in `CARDAMOM_MDF.c`.
 
-Suggested comparison settings:
+3. Set the intended number of chains for the new mode in `CARDAMOM_MDF.c`.
 
-| Purpose | `MCMCID` | Key settings |
-| --- | --- | --- |
-| Existing 400-chain affine-only baseline | 4 | `fADAPT=1`; fixed `nITERATIONS`; explicit `nWRITE`. |
-| Existing 400-chain DEMCMC-only baseline | 4 | `fADAPT=0`; fixed `nITERATIONS`; explicit `nWRITE`. |
-| Existing 400-chain affine-to-DEMCMC baseline | 4 | `0 < fADAPT < 1`; fixed `nITERATIONS`; explicit `nWRITE`. |
-| Small ranked DEMCMCZS test | 5 | Same EDC settings; production uses top EDC-passing chains. |
-| Full 400-chain EDC endpoint test | 6 | Same EDC settings; keeps all 400 chains for AFDEMCMC production. |
-| Affine-to-DEMCMCZS test | 7 | `fADAPT` sets affine fraction; DEMCMCZS uses ranked active chains after switch. |
-| DREAMZS comparison | 8 | Same EDC settings; explicit `nWRITE`; compare against modes 3 and 4. |
-| AIDE comparison | 9 | Same EDC settings; explicit `nWRITE`; compare against modes 3 and 4. |
-| AIDE-to-DEMCMC comparison | 10 | `fADAPT` sets AIDE fraction; remaining run uses DEMCMC. |
+4. Add a new `case` in the `switch (MCOPT.mcmcid)` block that calls the new sampler.
 
-For mode 4:
+5. Decide how EDC initialization should work in `FIND_EDC_INITIAL_VALUES.c`.
 
-```text
-fADAPT = 1.0 -> affine-only production
-fADAPT = 0.0 -> DEMCMC-only production
-0 < fADAPT < 1 -> affine phase followed by DEMCMC phase
-```
+6. Make sure the new mode receives `PI.parini` in the expected shape:
+   `nchains * npars`.
 
-For mode 10:
+7. Use the same output-writing convention as the existing samplers:
+   write results every `MCO.nWRITE` iterations.
 
-```text
-fADAPT = 0.3 -> first 30% HYBRID_AIDE, remaining 70% DEMCMC
-```
+8. Write restart files consistently if the sampler supports restart behavior.
+
+9. Recompile CARDAMOM and confirm that the executable timestamp changed. This ensures the run is using the newly compiled code rather than an older executable. 
+
+10. Run short diagnostic tests before launching long production runs.
+
+### Things to watch out for
+
+The EDC search and production sampler are separate phases. If the goal is to
+compare MCMC algorithms, the new mode should not accidentally use a different
+EDC search path, chain count, seed sequence, or EDC stopping rule unless that is
+the intended experiment.
+
+Chain count matters. Some modes keep all 400 EDC endpoints, while others rank
+EDC-passing chains and continue with a smaller active ensemble. This affects
+both the math of the sampler and the shape of the output files.
+
+Archive-based methods need extra care. If the sampler uses an archive `Z`, decide
+what goes into the archive, when archive rows are added, and whether early affine
+or warmup samples should be included.
+
+Proposal symmetry matters. Standard DEMCMC proposals are usually symmetric and
+do not need a Hastings correction. Affine/stretch proposals are not symmetric
+and require the affine Hastings correction. Hybrid proposals need careful
+checking so that the acceptance probability matches the actual proposal
+mechanism.
+
+Restart behavior can differ by mode. If a new sampler does not support restart
+or append behavior, document that clearly and avoid silent reuse of incompatible
+`START` files.
+
+Output size can grow quickly. `nWRITE`, `nITERATIONS`, and `nchains` together
+control how many parameter vectors are written. For early diagnostic runs, set
+`nWRITE` explicitly so the output is interpretable and comparable across modes.
 
 ## FAQ
 

--- a/doc/markdown_manuals/MCMC_IN_CARDAMOM_OVERVIEW.md
+++ b/doc/markdown_manuals/MCMC_IN_CARDAMOM_OVERVIEW.md
@@ -1,12 +1,219 @@
-# MCMC overview
+# MCMC in CARDAMOM overview
 
+CARDAMOM uses the `MCMCID` variable in the CBF NetCDF input file to select the
+MCMC algorithm used during model-data fusion. MCMC options are stored as
+attributes on `MCMCID`.
 
-FAQ:
+Common `MCMCID` attributes include:
 
-Q: Why does first half of output look systematically different?
+| Attribute | Meaning |
+| --- | --- |
+| `nITERATIONS` | Number of production MCMC iterations/generations. |
+| `nSAMPLES` | Number of requested output samples. Used to derive `nWRITE` if `nWRITE` is not set. |
+| `nWRITE` | Write interval for MCMC output. If unset, CARDAMOM uses `nITERATIONS / nSAMPLES`. |
+| `nPRINT` | Interval for printing progress information. |
+| `fADAPT` | Fraction of the production run assigned to the first proposal phase for hybrid modes. |
+| `nSAMPLES_EDC_SEARCH` | Number of iterations used in the EDC initial-condition search. |
+| `seed_number` | Random seed for deterministic/reproducible MCMC initialization and runs. |
 
-A: MCMC starts from random parameter combinations, and takes time to converge. Typically we discard first 50% of MCMC outputs
+## MCMC workflow
+
+CARDAMOM MCMC runs follow the same broad workflow:
+
+1. Read the CBF NetCDF file and `MCMCID` settings.
+2. Set the random seed from `seed_number`, using zero if no seed is provided.
+3. Search for parameter vectors that satisfy the EDCs.
+4. Hand the EDC-passing parameter vectors to the selected MCMC mode.
+5. Run production MCMC for `nITERATIONS` iterations.
+6. Write output every `nWRITE` iterations.
+7. Periodically write a `START` file that can be used to resume a run.
+
+The EDC search and production sampler are separate phases. `nWRITE` controls
+production output spacing, not EDC-search output.
+
+## EDC initial-condition search
+
+Before production MCMC, CARDAMOM searches for parameter vectors that satisfy
+EDCs. Modes 3-10 use the same deterministic 400-chain EDC search before
+mode-specific handoff. This makes comparisons among these modes more direct,
+because the initial EDC search uses the same chain count, same proposal path,
+same pass threshold, and same seed-controlled random sequence.
+
+For multi-chain EDC searches, CARDAMOM currently stops after more than 10 chains
+pass EDCs. Because the code checks `PEDCC > nstartchains` and `nstartchains=10`,
+this means at least 11 chains must pass EDCs before the search ends.
+
+## MCMC modes
+
+The CARDAMOM MDF executable currently dispatches the following MCMC modes:
+
+| MCMCID | Status | Production sampler | Chains after EDC handoff | Archive | Main proposal behavior |
+| --- | --- | --- | --- | --- | --- |
+| 119 | Existing/special | `MHMCMC_119` | 1 | No | Single-chain adaptive Metropolis-Hastings sampler. |
+| 2 | Existing | `DEMCMC` | 100 | No | Standard live-chain differential evolution MCMC. |
+| 3 | Existing | `ADEMCMC` | 400 | No | `fADAPT` controls an initial `STEP_ADEMCMC` phase, then switches to `STEP_DEMCMC`. |
+| 4 | Existing | `AFDEMCMC` | 400 | No | `fADAPT` controls an initial affine/stretch phase, then switches to `STEP_DEMCMC`. |
+| 5 | Added/experimental | `DEMCMCZS` | Top 10 EDC-passing chains | Yes | Archive-based differential evolution proposals plus snooker updates. |
+| 6 | Added/experimental | `AFDEMCMC` | 400 | Warmup only | Keeps all 400 EDC endpoints; can optionally warm up the best 10 with DEMCMCZS before AFDEMCMC production. |
+| 7 | Added/experimental | `AFDEMCMCZS` | 400 affine chains, then top 10 DEMCMCZS chains | Yes | `fADAPT` controls affine phase length, then active chains switch to DEMCMCZS using archive history. |
+| 8 | Added/experimental | `DREAMZS` | 400 | Yes | DREAMZS-lite archive proposals with crossover/subspace updates plus snooker updates. |
+| 9 | Added/experimental | `HYBRID_AIDE` | 400 | No | Each proposal combines CARDAMOM DEMCMC translation with affine/stretch moves. |
+| 10 | Added/experimental | `HYBRID_AIDE_DEMCMC` | 400 | No | `fADAPT` controls an initial HYBRID_AIDE phase, then switches to standard CARDAMOM DEMCMC. |
+
+## Proposal families
+
+Most multi-chain CARDAMOM MCMC modes are built from two proposal ideas:
+DEMCMC moves and affine/stretch moves. The different modes mainly change how
+these proposals are combined, when the sampler switches between them, and
+whether previous samples are stored in an archive.
+
+Mode 119 is the exception. It is the older single-chain adaptive
+Metropolis-Hastings path rather than a multi-chain ensemble method.
+
+### Single-chain adaptive Metropolis-Hastings
+
+The mode 119 sampler is the older single-chain adaptive Metropolis-Hastings
+path. It proposes from the current parameter vector, adapts proposal covariance
+during the adaptation portion of the run, and writes one chain.
+
+### DEMCMC
+
+DEMCMC proposes movement along the difference between two other live chains:
+
+```text
+new = current + gamma * (chain_a - chain_b) + noise
+```
+
+CARDAMOM's standard `DEMCMC` gamma convention is:
+
+```text
+90% of proposals: gamma = 0.1 * 2.38 / sqrt(2 * npars)
+10% of proposals: gamma = 1.0
+```
+
+This is the core differential-evolution proposal used directly in mode 2 and
+used after the initial phase in modes 3, 4, and 10.
+
+### Affine/stretch
+
+Affine ensemble proposals move one chain relative to another live chain using a
+stretch factor. This proposal is useful when parameters are correlated because
+the ensemble geometry helps choose directions and scales.
+
+```text
+new = chain_ref + z * (current - chain_ref)
+```
+
+The affine proposal has a non-symmetric proposal density, so CARDAMOM applies
+the affine Hastings correction:
+
+```text
+(npars - 1) * log(z)
+```
+
+where `z` is the stretch factor. This correction is required so that the
+proposal preserves detailed balance.
+
+This is the core affine proposal used directly in modes 4, 6, and 7, and used
+as one part of the hybrid AIDE proposal in modes 9 and 10.
+
+### Derived modes
+
+The remaining multi-chain modes are combinations or extensions of DEMCMC and
+affine/stretch proposals:
+
+| Method | Derived from | Description |
+| --- | --- | --- |
+| `ADEMCMC` | DEMCMC | Uses an adaptive differential-evolution-style proposal during the first `fADAPT` fraction of mode 3, then switches to DEMCMC. |
+| `AFDEMCMC` | Affine/stretch + DEMCMC | Uses affine/stretch proposals during the first `fADAPT` fraction of mode 4, then switches to DEMCMC. |
+| `DEMCMCZS` | DEMCMC | Uses archive differences from `Z` instead of only the current live ensemble, with occasional snooker proposals. |
+| `AFDEMCMCZS` | Affine/stretch + DEMCMCZS | Starts with affine/stretch proposals, then switches to archive-based DEMCMCZS proposals. |
+| `DREAMZS-lite` | DEMCMCZS | Adds crossover/subspace updates so some proposals update only a subset of parameters. |
+| `HYBRID_AIDE` | Affine/stretch + DEMCMC | Composes a DEMCMC translation with an affine/stretch move in a single proposal. |
+| `HYBRID_AIDE_DEMCMC` | HYBRID_AIDE + DEMCMC | Uses HYBRID_AIDE for the first `fADAPT` fraction, then switches to DEMCMC. |
+
+The archive-based modes, `DEMCMCZS` and `DREAMZS-lite`, are still DEMCMC-family
+methods. They differ from standard DEMCMC because proposal differences can be
+drawn from previous samples stored in `Z`, not only from the current live
+ensemble.
+
+The AIDE-family modes combine the two core proposal ideas. In `HYBRID_AIDE`,
+each chain independently chooses one of two proposal orderings:
+
+```text
+DEMCMC translation -> affine stretch
+affine stretch -> DEMCMC translation
+```
+
+The DEMCMC translation uses CARDAMOM's standard DEMCMC gamma convention. The
+affine part uses the affine Hastings correction:
+
+```text
+(npars - 1) * log(z)
+```
+
+## Suggested settings
+
+For standard mode comparisons, change only the settings required to select the
+mode or proposal split. Keep all other settings fixed:
+
+| Setting | Suggested value |
+| --- | --- |
+| `seed_number` | Same value across all compared runs. |
+| `nSAMPLES_EDC_SEARCH` | Same value across all compared runs. |
+| `nITERATIONS` | Same value across all compared runs. |
+| `nWRITE` | Set explicitly, especially for early-chain diagnostics. |
+| `nPRINT` | Same value across all compared runs. |
+| CBF data and priors | Identical except for intentional `MCMCID` settings. |
+| Executable | Same compiled executable. |
+| `START` file | Avoid unintended reuse when testing EDC behavior. |
+
+If `nWRITE` is unset, CARDAMOM derives it from:
+
+```text
+nITERATIONS / nSAMPLES
+```
+
+This is convenient for standard output, but explicit `nWRITE` is preferred when
+the goal is to compare early chain behavior.
+
+Suggested comparison settings:
+
+| Purpose | `MCMCID` | Key settings |
+| --- | --- | --- |
+| Existing 400-chain affine-only baseline | 4 | `fADAPT=1`; fixed `nITERATIONS`; explicit `nWRITE`. |
+| Existing 400-chain DEMCMC-only baseline | 4 | `fADAPT=0`; fixed `nITERATIONS`; explicit `nWRITE`. |
+| Existing 400-chain affine-to-DEMCMC baseline | 4 | `0 < fADAPT < 1`; fixed `nITERATIONS`; explicit `nWRITE`. |
+| Small ranked DEMCMCZS test | 5 | Same EDC settings; production uses top EDC-passing chains. |
+| Full 400-chain EDC endpoint test | 6 | Same EDC settings; keeps all 400 chains for AFDEMCMC production. |
+| Affine-to-DEMCMCZS test | 7 | `fADAPT` sets affine fraction; DEMCMCZS uses ranked active chains after switch. |
+| DREAMZS comparison | 8 | Same EDC settings; explicit `nWRITE`; compare against modes 3 and 4. |
+| AIDE comparison | 9 | Same EDC settings; explicit `nWRITE`; compare against modes 3 and 4. |
+| AIDE-to-DEMCMC comparison | 10 | `fADAPT` sets AIDE fraction; remaining run uses DEMCMC. |
+
+For mode 4:
+
+```text
+fADAPT = 1.0 -> affine-only production
+fADAPT = 0.0 -> DEMCMC-only production
+0 < fADAPT < 1 -> affine phase followed by DEMCMC phase
+```
+
+For mode 10:
+
+```text
+fADAPT = 0.3 -> first 30% HYBRID_AIDE, remaining 70% DEMCMC
+```
+
+## FAQ
+
+### Q: Why does the first half of output look systematically different?
+
+A: MCMC starts from initial parameter combinations and can take time to converge.
+It is common to discard the first portion of MCMC outputs as burn-in. The exact
+burn-in fraction should be chosen based on the sampler, run length, and
+diagnostics for the analysis.
 
 <img width="356" alt="image" src="https://user-images.githubusercontent.com/23563444/208981078-91bc8c55-c6de-407e-aff4-98e74aad02d7.png">
-Figure 1: Example of full output, we discard first 50%.
 
+Figure 1: Example of full output where early samples differ from later samples.


### PR DESCRIPTION
These updates address the following:

1. Add a tunable `nWRITE` `MCMCID` attribute for controlling write frequency directly from CBF files.
2. Standardize the 400-chain EDC search path for MCMC modes 3-10, so these modes use the same deterministic EDC initialization before mode-specific handoff.
3. Add archive-based `DEMCMCZS` support and mode 5 production behavior.
4. Add hybrid affine/archive samplers for modes 6 and 7.
5. Add `DREAMZS-lite` as mode 8.
6. Add `HYBRID_AIDE` proposal modes 9 and 10.
7. Update MCMC documentation 

## File-Level Changes

**`../C/projects/CARDAMOM_GENERAL/CARDAMOM_NETCDF_DATA_STRUCTURE.c`**

Adds `nWRITE` to `MCMCID_STRUCT`.

**`../C/projects/CARDAMOM_GENERAL/CARDAMOM_READ_NETCDF_DATA.c`**

Reads `MCMCID:nWRITE` from the CBF NetCDF attributes.

**`../PYTHON/CARDAMOM_WRITE_CBF_NC_FILE.py`**

Adds default `nWRITE = -9999.0` to the Python CBF writer. If unset, CARDAMOM falls back to the previous `nITERATIONS / nSAMPLES` behavior.

**`../C/projects/CARDAMOM_MDF/CARDAMOM_MDF.c`**

Adds `MCMCID` dispatch and default chain counts for modes 5-10.

- Mode 5: `DEMCMCZS`
- Mode 6: `AFDEMCMC` after EDC handoff/warmup logic
- Mode 7: `AFDEMCMCZS`
- Mode 8: `DREAMZS`
- Mode 9: `HYBRID_AIDE`
- Mode 10: `HYBRID_AIDE_DEMCMC`

**`../C/projects/CARDAMOM_MDF/MCMC_SETUP/PROJECT_FUN/FIND_EDC_INITIAL_VALUES.c`**

Standardizes the EDC search for modes 3-10 using the same 400-chain `ADEMCMC` EDC search. Mode-specific handoff now occurs only after the shared EDC search.

Additional behavior:

- Mode 5 ranks EDC-passing chains by full likelihood and keeps the best production chains.
- Mode 6 keeps all 400 EDC endpoint chains and optionally applies `DEMCMCZS` warmup to the best 10 before returning to 400-chain `AFDEMCMC` production.
- Current warmup is disabled with `WARMUP_ITERS=0`.

**`../C/mcmc_fun/MHMCMC/MCMC_FUN/STEP_DEMCMCZS.c`**

Adds `DEMCMCZS` archive proposal steps: parallel archive-difference moves and snooker moves.

**`../C/mcmc_fun/MHMCMC/MCMC_FUN/DEMCMCZS.c`**

Adds the `DEMCMCZS` sampler using archive-based differential evolution proposals with 10% snooker updates.

**`../C/mcmc_fun/MHMCMC/MCMC_FUN/DEMCMCZS_WARMUP.c`**

Adds a helper for short `DEMCMCZS` warmup of selected chains before reinserting them into the larger ensemble.

**`../C/mcmc_fun/MHMCMC/MCMC_FUN/AFDEMCMCZS.c`**

Adds the mode 7 sampler: affine phase controlled by `fADAPT`, followed by `DEMCMCZS` using archive history and selected active chains.

**`../C/mcmc_fun/MHMCMC/MCMC_FUN/STEP_DREAMZS.c`**

Adds `DREAMZS-lite` proposal step using archive differences with crossover/subspace updates.

**`../C/mcmc_fun/MHMCMC/MCMC_FUN/DREAMZS.c`**

Adds the mode 8 sampler using `DEMCMCZS`-style archive proposals plus DREAM-style crossover probabilities.

**`../C/mcmc_fun/MHMCMC/MCMC_FUN/STEP_HYBRID_AIDE.c`**

Adds `HYBRID_AIDE` proposal step combining CARDAMOM `DEMCMC` translation with affine stretch proposals. Uses CARDAMOM’s `DEMCMC` gamma convention: 90% small `0.1 * textbook gamma` moves and 10% full `gamma = 1.0` moves.

**`../C/mcmc_fun/MHMCMC/MCMC_FUN/HYBRID_AIDE.c`**

Adds the mode 9 sampler using `HYBRID_AIDE` proposals throughout production.

**`../C/mcmc_fun/MHMCMC/MCMC_FUN/HYBRID_AIDE_DEMCMC.c`**

Adds the mode 10 sampler where `fADAPT` controls the transition from `HYBRID_AIDE` to standard CARDAMOM `DEMCMC`. For example, `fADAPT=0.3` gives 30% AIDE and 70% DEMCMC.

**`../.gitignore`**

Adds `*.log*` so local MCMC run logs are not tracked.

**`../doc/markdown_manuals/MCMC_IN_CARDAMOM_OVERVIEW.md`** 

Documentation for MCMC. Suggestions for default settings, algorithmic documentation, guide for adding new MCMC id's. 